### PR TITLE
Try to fix race condition in testing

### DIFF
--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -7,6 +7,7 @@ which will allow the remaining test to use the GPU.
 """
 import unittest
 import pathlib
+import time
 import numpy as np
 import voltools as vt
 import multiprocessing
@@ -74,6 +75,8 @@ class TestTMJob(unittest.TestCase):
         try:
             _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], unittest_mute=True)
         except RuntimeError:
+            # sleep a second to make sure all children are cleaned
+            time.sleep(1)
             self.assertEqual(len(multiprocessing.active_children()), 0,
                              msg='a process was still lingering after a parallel job with partially invalid resources '
                                  'was started')


### PR DESCRIPTION
Tests had a non-insignificant chance of failing due to this condition being triggerd.
I added a 1 sec wait between raising the error and seeing if all children are dead to hopefully solve this issue