### PR TITLE
update readme to point to pip install instead of source

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ python -m pip install pytom-match-pick
 ```
 
 ## Cupy warning
-Trying to import the code with 
+Having issues running the software? If cupy is not correctly installed, 
 ```commandline
 python -c "import pytom_tm"
 ```
 
 can show a cupy warning. If this is the case, this probably means cupy is not correctly installed.
-If your cupy installation is broken, the following should raise some errors:
+Alternatively, cupy can sometimes be installed without issue but not detect CUDA correctly. In that case, the following should raise some errors:
 ```commandline
 python -c "import cupy as cp; a = cp.zeros((100,100))"
 ```

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Once the environment is created, activate it:
 conda activate pytom_tm
 ```
 
-The install the code with `pip` (building cupy can take a while!):
+Then install the code with `pip` (building cupy can take a while!):
 
 ```commandline
-python -m pip install pytom-match-pick.[plotting]
+python -m pip install pytom-match-pick[plotting]
 ```
 
 The installation above also adds the optional dependencies `[matplotlib, seaborn]` which are required to run 
@@ -81,7 +81,7 @@ The following scripts are available to run with `--help` to see parameters:
 - merge multiple star files to a single starfile: `pytom_merge_stars.py --help`
 
 ## Developer install
-If you want the most up-to-date version of the code you can get it from this repository via:
+If you want the most up-to-date version of the code you can get install it from this repository via:
 
 ```commandline
 git clone https://github.com/SBC-Utrecht/pytom-match-pick.git
@@ -91,7 +91,7 @@ python -m pip install '.[plotting]'
 
 as above, if you don't want the optional plotting dependencies use the following install command instead:
 ```commandline
-python -m pip install '.[plotting]'
+python -m pip install .
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ Once the environment is created, activate it:
 conda activate pytom_tm
 ```
 
-Then clone the repository and install it with pip (building cupy can take a while!): 
+The install the code with `pip` (building cupy can take a while!):
 
 ```commandline
-git clone https://github.com/SBC-Utrecht/pytom-match-pick.git
-cd pytom-match-pick
-python -m pip install '.[plotting]'
+python -m pip install pytom-match-pick.[plotting]
 ```
 
 The installation above also adds the optional dependencies `[matplotlib, seaborn]` which are required to run 
@@ -48,20 +46,17 @@ The installation above also adds the optional dependencies `[matplotlib, seaborn
 (such as certain cluster environments) it might be desirable to skip them. In that case remove `[plotting]` from the pip install command:
 
 ```commandline
-python -m pip install .
+python -m pip install pytom-match-pick
 ```
 
-## Tests
-
-To run the unittests:
-
+## Cupy warning
+Trying to import the code with 
 ```commandline
-cd tests
-python -m unittest discover
+python -c "import pytom_tm"
 ```
 
-If cupy is not correctly installed, this should raise some errors:
-
+can show a cupy warning. If this is the case, this probably means cupy is not correctly installed.
+If your cupy installation is broken, the following should raise some errors:
 ```commandline
 python -c "import cupy as cp; a = cp.zeros((100,100))"
 ```
@@ -84,6 +79,30 @@ The following scripts are available to run with `--help` to see parameters:
 - extract candidates from a job file (.json) created in the template matching output folder: `pytom_extract_candidate.py --help`
 - estimate an ROC curve from a job file (.json): `pytom_estimate_roc.py --help`
 - merge multiple star files to a single starfile: `pytom_merge_stars.py --help`
+
+## Developer install
+If you want the most up-to-date version of the code you can get it from this repository via:
+
+```commandline
+git clone https://github.com/SBC-Utrecht/pytom-match-pick.git
+cd pytom-match-pick
+python -m pip install '.[plotting]'
+```
+
+as above, if you don't want the optional plotting dependencies use the following install command instead:
+```commandline
+python -m pip install '.[plotting]'
+```
+
+## Tests
+
+With the developer install also comes the ability to run the unittests,
+from the git repository run:
+
+```commandline
+cd tests
+python -m unittest discover
+```
 
 ## Contributing
 


### PR DESCRIPTION
Now that the pip install commands are working, we should update our installation instructions as well