### PR TITLE
ctf model ramp weighting correction and updated interpolation center

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.4.3"
+version = "0.5.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -513,22 +513,16 @@ def _create_tilt_weighted_wedge(
                     ctf_params_per_tilt[i]['cs'] * 1e-3,
                     flip_phase=True  # creating a per tilt ctf is hard if the phase is not flipped
                 ), axes=0,
-            ) * exact_weighting
+            )
             tilt[:, :, image_size // 2] = np.concatenate(
                 (  # duplicate and flip the CTF around the 0 frequency; then concatenate to make it non-reduced
                     np.flip(ctf[:, 1: 1 + image_size - ctf.shape[1]], axis=1),
                     ctf
                 ),
                 axis=1
-            )
+            ) * exact_weighting
         else:
-            tilt[:, :, image_size // 2] = np.concatenate(
-                (  # duplicate and flip the CTF around the 0 frequency; then concatenate to make it non-reduced
-                    np.flip(exact_weighting[:, 1: 1 + image_size - exact_weighting.shape[1]], axis=1),
-                    exact_weighting
-                ),
-                axis=1
-            )
+            tilt[:, :, image_size // 2] = exact_weighting
 
         # rotate the image weights to the tilt angle
         rotated = np.flip(

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -487,7 +487,10 @@ def _create_tilt_weighted_wedge(
     image_size = shape[0]  # assign to size variable as all dimensions are equal size
     tilt = np.zeros(shape)
     q_grid = radial_reduced_grid(shape)
-    _, q_grid_1d = radial_average(np.fft.ifftshift(q_grid, axes=(0, 1)))
+    q_grid_1d = np.abs(np.arange(
+        -image_size // 2 + image_size % 2,
+        image_size // 2 + image_size % 2, 1.
+    )) / (image_size // 2)
     tilt_weighted_wedge = np.zeros((image_size, image_size, image_size // 2 + 1))
 
     for i, alpha in enumerate(tilt_angles):
@@ -495,7 +498,7 @@ def _create_tilt_weighted_wedge(
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
         overlap = sampling / (2 / image_size)
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
-        exact_weighting = np.fft.fftshift(profile_to_weighting(exact_filter, (image_size, ) * 2), axes=0)
+        exact_weighting = np.tile(exact_filter, (image_size, 1)).T
 
         if ctf_params_per_tilt is not None:
             ctf = np.fft.fftshift(

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -497,7 +497,7 @@ def _create_tilt_weighted_wedge(
     )) / (image_size // 2)
     tilt_increment = min([abs(x - y) for x, y in pairwise(tilt_angles)])
     overlap_frequency = tilt_increment * image_size / 2
-    ramp_filter = q_grid_1d / overlap_frequency + 1 / len(tilt_angles)
+    ramp_filter = q_grid_1d / overlap_frequency
     ramp_filter[ramp_filter > 1] = 1
     ramp_weighting = np.tile(ramp_filter, (image_size, 1)).T
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -497,7 +497,7 @@ def _create_tilt_weighted_wedge(
         # calculate weighting correction for overlapping data
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
         smallest_sampling = np.min(sampling[sampling > 0.001])
-        slice_width = min(1, smallest_sampling * image_size)
+        slice_width = smallest_sampling * (image_size / 2)
         overlap = sampling / slice_width
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
         exact_weighting = np.tile(exact_filter, (image_size, 1)).T

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy.typing as npt
 import logging
 import scipy.ndimage as ndimage
+import voltools as vt
 from typing import Optional, Union
 from pytom_tm.io import UnequalSpacingError
 
@@ -513,13 +514,16 @@ def _create_tilt_weighted_wedge(
 
         # rotate the image weights to the tilt angle
         rotated = np.flip(
-            ndimage.rotate(
+            vt.transform(
                 tilt,
-                np.rad2deg(alpha),
-                axes=(0, 2),
-                reshape=False,
-                order=3
-            )[:, :, : image_size // 2 + 1]
+                rotation=(0, alpha, 0),
+                rotation_units='rad',
+                rotation_order='rxyz',
+                center=(image_size // 2, ) * 3,
+                interpolation='filt_bspline',
+                device='cpu'
+            )[:, :, : image_size // 2 + 1],
+            axis=2
         )
 
         # weight with exposure and tilt dampening

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -496,7 +496,9 @@ def _create_tilt_weighted_wedge(
     for i, alpha in enumerate(tilt_angles):
         # calculate weighting correction for overlapping data
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
-        overlap = sampling / (2 / image_size)
+        smallest_sampling = np.min(sampling[sampling > 0.001])
+        slice_width = min(1, smallest_sampling * (image_size // 2))
+        overlap = sampling / slice_width
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
         exact_weighting = np.tile(exact_filter, (image_size, 1)).T
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -5,6 +5,7 @@ import scipy.ndimage as ndimage
 import voltools as vt
 from typing import Optional, Union
 from pytom_tm.io import UnequalSpacingError
+from itertools import pairwise
 
 
 constants = {
@@ -494,9 +495,9 @@ def _create_tilt_weighted_wedge(
         -image_size // 2 + image_size % 2,
         image_size // 2 + image_size % 2, 1.
     )) / (image_size // 2)
-    tilt_increment = (np.abs(np.array(tilt_angles)[1:] - np.array(tilt_angles)[:-1])).min()
+    tilt_increment = min([abs(x - y) for x, y in pairwise(tilt_angles)])
     overlap_frequency = tilt_increment * image_size / 2
-    ramp_filter = q_grid_1d / overlap_frequency
+    ramp_filter = q_grid_1d / overlap_frequency + 1 / len(tilt_angles)
     ramp_filter[ramp_filter > 1] = 1
     ramp_weighting = np.tile(ramp_filter, (image_size, 1)).T
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -537,7 +537,7 @@ def _create_tilt_weighted_wedge(
                 center=(image_size // 2, ) * 3,
                 interpolation='filt_bspline',
                 device='cpu'
-            )[:, :, : image_size // 2 + 1],
+            )[:, :, :image_size // 2 + 1],  # crop back z-axis to reduced Fourier form
             axis=2
         )
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -494,9 +494,9 @@ def _create_tilt_weighted_wedge(
     q_grid_1d = np.abs(np.arange(
         -image_size // 2 + image_size % 2,
         image_size // 2 + image_size % 2, 1.
-    )) / (image_size // 2)
+    )) / (image_size // 2) * 0.5  # to nyquist
     tilt_increment = min([abs(x - y) for x, y in pairwise(tilt_angles)])
-    overlap_frequency = tilt_increment * image_size / 2
+    overlap_frequency = 1 / (tilt_increment * image_size)
     ramp_filter = q_grid_1d / overlap_frequency
     ramp_filter[ramp_filter > 1] = 1
     ramp_weighting = np.tile(ramp_filter, (image_size, 1)).T

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -497,7 +497,7 @@ def _create_tilt_weighted_wedge(
         # calculate weighting correction for overlapping data
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
         smallest_sampling = np.min(sampling[sampling > 0.001])
-        slice_width = min(1, smallest_sampling * (image_size // 2))
+        slice_width = min(1, smallest_sampling * image_size)
         overlap = sampling / slice_width
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
         exact_weighting = np.tile(exact_filter, (image_size, 1)).T

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -556,7 +556,7 @@ def _create_tilt_weighted_wedge(
                     np.cos(alpha)  # apply tilt-dependent weighting
             )
 
-        tilt_weighted_wedge += weighted_tilt  # np.maximum(tilt_weighted_wedge, weighted_tilt)
+        tilt_weighted_wedge += weighted_tilt
 
     tilt_weighted_wedge[q_grid > cut_off_radius] = 0
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -496,7 +496,7 @@ def _create_tilt_weighted_wedge(
     for i, alpha in enumerate(tilt_angles):
         # calculate weighting correction for overlapping data
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
-        overlap = sampling / (2 / image_size)
+        overlap = sampling / (2 / (image_size//2))
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
         exact_weighting = np.tile(exact_filter, (image_size, 1)).T
 

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -490,13 +490,13 @@ def _create_tilt_weighted_wedge(
     q_grid_1d = np.abs(np.arange(
         -image_size // 2 + image_size % 2,
         image_size // 2 + image_size % 2, 1.
-    )) / (image_size // 2)
+    ))  # / (image_size // 2)
     tilt_weighted_wedge = np.zeros((image_size, image_size, image_size // 2 + 1))
 
     for i, alpha in enumerate(tilt_angles):
         # calculate weighting correction for overlapping data
         sampling = np.sin(np.abs((np.array(tilt_angles) - alpha)))
-        overlap = sampling / (2 / (image_size//2))
+        overlap = sampling / (2 / image_size)
         exact_filter = 1 / np.clip(1 - (overlap[:, np.newaxis] * q_grid_1d) ** 2, 0, 2).sum(axis=0)
         exact_weighting = np.tile(exact_filter, (image_size, 1)).T
 


### PR DESCRIPTION
This PR updates internal code in _create_tilt_weighted_wedge to create a more precise weighting function.

First I add a linear weighting up to the point where tilt image overlap in Fourier space. This now allows summation of the tilts instead of doing a maximum operation. It reduces aliasing artifacts quite a lot:

Before:
![ctf_model_before_0 5](https://github.com/SBC-Utrecht/pytom-match-pick/assets/58044494/acfcb61c-23c1-48d9-bcb5-4845c32ec18f)

After:
![ctf_model_after_0 5](https://github.com/SBC-Utrecht/pytom-match-pick/assets/58044494/0bb4ee87-c815-4dbd-915f-3816caab0d8a)

The second update (which is also visible in the image, but difficult to see), is that I changed the interpolation center when tilting the images. I switched to voltools instead of ndimage.rotate as this allows me to set the center to the origin in Fourier space, while ndimage.rotate instead uses (shape - 1) / 2, which is not correct for fourier space. In the above image the wedge is shifted one pixel to the left. But this can be quite crucial for the overlap of low frequencies between the tomo and template.