### PR TITLE
change 'ptm' to 'rln' in the extraction star file

### DIFF
--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -260,17 +260,17 @@ def extract_particles(
         ] *= cut_mask
 
     output = pd.DataFrame(data, columns=[
-        'ptmCoordinateX',
-        'ptmCoordinateY',
-        'ptmCoordinateZ',
-        'ptmAngleRot',
-        'ptmAngleTilt',
-        'ptmAnglePsi',
-        'ptmLCCmax',
-        'ptmCutOff',
-        'ptmSearchStd',
-        'ptmDetectorPixelSize',
-        'ptmMicrographName',
+        'rlnCoordinateX',
+        'rlnCoordinateY',
+        'rlnCoordinateZ',
+        'rlnAngleRot',
+        'rlnAngleTilt',
+        'rlnAnglePsi',
+        'rlnLCCmax',
+        'rlnCutOff',
+        'rlnSearchStd',
+        'rlnDetectorPixelSize',
+        'rlnMicrographName',
     ]), scores
 
     if plotting_available and create_plot:


### PR DESCRIPTION
should close #93

@McHaillet I did not see any other reference to 'ptm', however these do not have the underscore, is that correct?

