### PR TITLE
default value phase shift entry point

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -780,6 +780,7 @@ def match_template(argv=None):
         "--phase-shift",
         type=float,
         required=False,
+        default=.0,
         action=LargerThanZero,
         help="Phase shift (in degrees) for the CTF to model phase plates.",
     )


### PR DESCRIPTION
While running realised this issue: phase shift needs to be 0 by default otherwise None gets passed to CTF creation.