### PR TITLE
Relion5 compatibility

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -465,11 +465,11 @@ def extract_candidates(argv=None):
              "leave at 1."
     )
     parser.add_argument(
-        '--centered-coordinates',
+        '--relion5-compat',
         action="store_true",
         default=False,
         required=False,
-        help="Write out centered coordinates for RELION5."
+        help="Write out centered coordinates in Angstrom for RELION5."
     )
     parser.add_argument(
         "--log",
@@ -493,6 +493,7 @@ def extract_candidates(argv=None):
         tomogram_mask_path=args.tomogram_mask,
         tophat_filter=args.tophat_filter,
         tophat_connectivity=args.tophat_connectivity,
+        relion5_compat=args.relion5_compat,
     )
 
     # write out as a RELION type starfile

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -465,6 +465,13 @@ def extract_candidates(argv=None):
              "leave at 1."
     )
     parser.add_argument(
+        '--centered-coordinates',
+        action="store_true",
+        default=False,
+        required=False,
+        help="Write out centered coordinates for RELION5."
+    )
+    parser.add_argument(
         "--log",
         type=str,
         required=False,

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -161,6 +161,7 @@ def extract_particles(
         connectivity of kernel for tophat transform
     relion5_compat: bool, default False
         relion5 compatibility writes coordinates relative to center and in Angstrom
+        center definition should be: tomo_shape / 2 - 1
 
     Returns
     -------


### PR DESCRIPTION
closes #177 

Coordinates are written relative to the tomogram center and in Angstrom (instead of nr of voxels). Some star file column header names also changed. 

I checked with relion what definition if of the tomogram center: 3dem/relion#1137