### PR TITLE
Center of mass fix

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -75,8 +75,8 @@ def generate_template_from_map(
         logging.debug(
             f'size check {output_box_size} > {(input_map.shape[0] * input_spacing) // output_spacing}')
         if output_box_size > (input_map.shape[0] * input_spacing) // output_spacing:
-            pad = int(output_box_size * (output_spacing / input_spacing)) - \
-                  input_map.shape[0]
+            pad = (int(output_box_size * (output_spacing / input_spacing)) - 
+                   input_map.shape[0])
             logging.debug(f'pad with this number of zeros: {pad}')
             input_map = np.pad(
                 input_map,

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -59,11 +59,24 @@ def generate_template_from_map(
         logging.warning(warning_text)
         filter_to_resolution = 2 * output_spacing
 
+    if center:
+        volume_center = np.divide(np.subtract(input_map.shape, 1), 2, dtype=np.float32)
+        # square input to make values positive for center of mass
+        input_center_of_mass = center_of_mass(input_map ** 2)
+        shift = np.subtract(volume_center, input_center_of_mass)
+        input_map = vt.transform(input_map, translation=shift, device='cpu')
+
+        logging.debug(f'center of mass, before was '
+                      f'{np.round(input_center_of_mass, 2)} '
+                      f'and after {np.round(center_of_mass(input_map ** 2), 2)}')
+
     # extend volume to the desired output size before applying convolutions!
     if output_box_size is not None:
-        logging.debug(f'size check {output_box_size} > {(input_map.shape[0] * input_spacing) // output_spacing}')
+        logging.debug(
+            f'size check {output_box_size} > {(input_map.shape[0] * input_spacing) // output_spacing}')
         if output_box_size > (input_map.shape[0] * input_spacing) // output_spacing:
-            pad = int(output_box_size * (output_spacing / input_spacing)) - input_map.shape[0]
+            pad = int(output_box_size * (output_spacing / input_spacing)) - \
+                  input_map.shape[0]
             logging.debug(f'pad with this number of zeros: {pad}')
             input_map = np.pad(
                 input_map,
@@ -71,20 +84,12 @@ def generate_template_from_map(
                 mode='constant',
                 constant_values=0
             )
-        elif output_box_size < (input_map.shape[0] * input_spacing) // output_spacing:
-            logging.warning('Could not set specified box size as the map would need to be cut and this might '
-                            'result in loss of information of the structure. Please decrease the box size of the map '
-                            'by hand (e.g. chimera)')
-
-    if center:
-        volume_center = np.divide(np.subtract(input_map.shape, 1), 2, dtype=np.float32)
-        input_center_of_mass = center_of_mass(input_map)
-        shift = np.subtract(volume_center, input_center_of_mass)
-        input_map = vt.transform(input_map, translation=shift, device='cpu')
-
-        logging.debug(f'center of mass, before was '
-                      f'{np.round(input_center_of_mass, 2)} '
-                      f'and after {np.round(center_of_mass(input_map), 2)}')
+        elif output_box_size < (
+                input_map.shape[0] * input_spacing) // output_spacing:
+            logging.warning(
+                'Could not set specified box size as the map would need to be cut and this might '
+                'result in loss of information of the structure. Please decrease the box size of the map '
+                'by hand (e.g. chimera)')
 
     # create low pass filter
     lpf = create_gaussian_low_pass(

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -49,6 +49,12 @@ class TestTemplate(unittest.TestCase):
             self.template_center)
         diff = np.abs(diff).sum()
         self.assertTrue(diff < 1, msg="Total shift difference should be small")
+        # absolute of template should be identical due to square
+        abs_template = generate_template_from_map(
+            np.abs(self.template), 1, 1, center=True,
+        )
+        diff = np.abs(new_template - abs_template).sum()
+        self.assertTrue(diff == 0, msg="Absolute should provide exactly same center")
 
     def test_lowpass_resolution(self):
         # Test too low filter resolution

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -53,8 +53,12 @@ class TestTemplate(unittest.TestCase):
         abs_template = generate_template_from_map(
             np.abs(self.template), 1, 1, center=True,
         )
-        diff = np.abs(new_template - abs_template).sum()
-        self.assertTrue(diff == 0, msg="Absolute should provide exactly same center")
+        diff = (
+                np.array(center_of_mass(new_template ** 2)) -
+                np.array(center_of_mass(abs_template ** 2))
+        )
+        diff = np.abs(diff).sum()
+        self.assertTrue(diff < 1, msg="Absolute should provide exactly same center")
 
     def test_lowpass_resolution(self):
         # Test too low filter resolution

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,12 +1,14 @@
 import unittest
 import numpy as np
 from pytom_tm.template import generate_template_from_map
+from scipy.ndimage import center_of_mass
 
 
 class TestTemplate(unittest.TestCase):
     def setUp(self):
         self.template = np.zeros((13, 13, 13), dtype=np.float32)
-        self.template[3:5, 3:5, 7:9] = 1
+        self.template[2:5, 2:5, 7:9] = -1
+        self.template[3:5, 3:5, 7:9] = 2
 
     def test_template_padding(self):
         uneven_box = np.zeros((13, 13, 7))
@@ -35,13 +37,17 @@ class TestTemplate(unittest.TestCase):
             self.template, 1, 1, center=False,
         )
         square_sum = np.square(new_template - self.template).sum()
-        self.assertTrue(square_sum < 1, msg="Template should not change strongly "
+        self.assertTrue(square_sum < 10, msg="Template should not change strongly "
                                             "without recentering.")
         new_template = generate_template_from_map(
             self.template, 1, 1, center=True,
         )
         square_sum = np.square(new_template - self.template).sum()
-        self.assertTrue(square_sum > 1, msg="Template didnt change after shift")
+        self.assertTrue(square_sum > 10, msg="Template didnt change after shift")
+        print(center_of_mass(self.template))
+        print(center_of_mass(self.template**2))
+        print(center_of_mass(new_template))
+        print(center_of_mass(new_template**2))
 
     def test_lowpass_resolution(self):
         # Test too low filter resolution

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -9,6 +9,7 @@ class TestTemplate(unittest.TestCase):
         self.template = np.zeros((13, 13, 13), dtype=np.float32)
         self.template[2:5, 2:5, 7:9] = -1
         self.template[3:5, 3:5, 7:9] = 2
+        self.template_center = (6, 6, 6)
 
     def test_template_padding(self):
         uneven_box = np.zeros((13, 13, 7))
@@ -44,10 +45,10 @@ class TestTemplate(unittest.TestCase):
         )
         square_sum = np.square(new_template - self.template).sum()
         self.assertTrue(square_sum > 10, msg="Template didnt change after shift")
-        print(center_of_mass(self.template))
-        print(center_of_mass(self.template**2))
-        print(center_of_mass(new_template))
-        print(center_of_mass(new_template**2))
+        diff = np.array(center_of_mass(new_template**2)) - np.array(
+            self.template_center)
+        diff = np.abs(diff).sum()
+        self.assertTrue(diff < 1, msg="Total shift difference should be small")
 
     def test_lowpass_resolution(self):
         # Test too low filter resolution


### PR DESCRIPTION
Fix for the center of mass. I am not fully sure about the unittest check yet though, maybe you have a better solution. Currently checking with the same method as I am using internally.

I also switched to box padding after recentering. That is the better order as the padding is anyway done with zeros.

Closes #173

The square seems to work nicely though. This is an example that was failing before:
 
![centering_before_fix](https://github.com/SBC-Utrecht/pytom-match-pick/assets/58044494/8bdfd18b-c839-4d04-bd78-fe1266d084ef)

And not works much better:

![centering_after_fix](https://github.com/SBC-Utrecht/pytom-match-pick/assets/58044494/1b1e1078-ecba-48a7-9512-b50af2219adf)



