### PR TITLE
phase randomization score map correction

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -758,6 +758,7 @@ def match_template(argv=None):
     )
     additional_group = parser.add_argument_group('Additional options')
     additional_group.add_argument(
+        "-r",
         "--random-phase-correction",
         action="store_true",
         default=False,

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -20,6 +20,7 @@ from pytom_tm.io import (
     BetweenZeroAndOne,
 )
 from pytom_tm.tmjob import load_json_to_tmjob
+from os import urandom
 
 
 def _parse_argv(argv=None):
@@ -771,7 +772,7 @@ def match_template(argv=None):
     additional_group.add_argument(
         "--rng-seed",
         action=LargerThanZero,
-        default=321,
+        default=int.from_bytes(urandom(8)),
         required=False,
         help="Specify a seed for the random number generator used for phase "
              "randomization for consistent results!"

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -756,6 +756,25 @@ def match_template(argv=None):
         "apply it to the tomogram patch and template. Effectively puts more weight on "
         "high resolution features and sharpens the correlation peaks.",
     )
+    additional_group = parser.add_argument_group('Additional options')
+    additional_group.add_argument(
+        "--random-phase-correction",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Run template matching simultaneously with a phase randomized version of "
+             "the template, and subtract this 'noise' map from the final score map. "
+             "For this method please see STOPGAP as a reference: "
+             "https://doi.org/10.1107/S205979832400295X ."
+    )
+    additional_group.add_argument(
+        "--rng-seed",
+        action=LargerThanZero,
+        default=321,
+        required=False,
+        help="Specify a seed for the random number generator used for phase "
+             "randomization for consistent results!"
+    )
     device_group = parser.add_argument_group('Device control')
     device_group.add_argument(
         "-g",
@@ -836,6 +855,8 @@ def match_template(argv=None):
         whiten_spectrum=args.spectral_whitening,
         rotational_symmetry=args.z_axis_rotational_symmetry,
         particle_diameter=args.particle_diameter,
+        random_phase_correction=args.random_phase_correction,
+        rng_seed=args.rng_seed,
     )
 
     score_volume, angle_volume = run_job_parallel(

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -117,7 +117,7 @@ class TemplateMatchingGPU:
 
         The precalculation of conjugated FTs of the tomo was (AFAIK) introduced
         by STOPGAP! Also, they introduced simultaneous matching with a phase randomized
-        version of the template.
+        version of the template. https://doi.org/10.1107/S205979832400295X
 
         Parameters
         ----------

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -116,7 +116,8 @@ class TemplateMatchingGPU:
         - pyTME: https://github.com/KosinskiLab/pyTME
 
         The precalculation of conjugated FTs of the tomo was (AFAIK) introduced
-        by STOPGAP!
+        by STOPGAP! Also, they introduced simultaneous matching with a phase randomized
+        version of the template.
 
         Parameters
         ----------

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -336,9 +336,10 @@ class TemplateMatchingGPU:
 
         # do the noise correction on the scores map: substract the noise scores first,
         # and then add the noise mean to ensure stats are consistent
-        self.plan.scores = (
-            (self.plan.scores - self.plan.noise_scores) + self.plan.noise_scores.mean()
-        )
+        if self.noise_correction:
+            self.plan.scores = (
+                (self.plan.scores - self.plan.noise_scores) + self.plan.noise_scores.mean()
+            )
 
         # Get correct orientation back!
         # Use same method as William Wan's STOPGAP
@@ -410,7 +411,7 @@ update_results_kernel = cp.ElementwiseKernel(
 update_noise_template_results_kernel = cp.ElementwiseKernel(
     'float32 scores, float32 ccc_map',
     'float32 scores_out',
-    'if (scores < ccc_map) {scores_out = ccc_map}',
+    'if (scores < ccc_map) {scores_out = ccc_map;}',
     'update_noise_template_results'
 )
 

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -4,10 +4,9 @@ import numpy.typing as npt
 import voltools as vt
 import gc
 from typing import Optional
-from cupyx.scipy.fft import rfftn, irfftn, fftshift
+from cupyx.scipy.fft import rfftn, irfftn
 from tqdm import tqdm
 from pytom_tm.correlation import mean_under_mask, std_under_mask
-from packaging import version
 
 
 class TemplateMatchingPlan:

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -144,7 +144,7 @@ def phase_randomize_template(
 
     # construct the new template
     noise = np.reshape(noise, amplitude.shape)
-    result = np.fft.irfftn(
+    result = irfftn(
         amplitude * np.exp(1j * noise), s=template.shape
     )
     return result

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -129,7 +129,7 @@ def phase_randomize_template(
     result: npt.NDArray[float]
         phase randomized version of the template
     """
-    ft = np.fft.rfftn(template)
+    ft = rfftn(template)
     amplitude = np.abs(ft)
 
     # permute the phases in flattened version of the array

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -5,7 +5,12 @@ import logging
 from scipy.ndimage import center_of_mass, zoom
 from scipy.fft import rfftn, irfftn
 from typing import Optional
-from pytom_tm.weights import create_gaussian_low_pass
+from pytom_tm.weights import (
+    create_ctf,
+    create_gaussian_low_pass,
+    radial_average,
+    radial_reduced_grid,
+)
 
 
 def generate_template_from_map(
@@ -103,3 +108,43 @@ def generate_template_from_map(
         irfftn(rfftn(input_map) * lpf, s=input_map.shape),
         input_spacing / output_spacing
     )
+
+
+def phase_randomize_template(
+        template: npt.NDArray[float],
+        seed: int = 321,
+):
+    """Create a version of the template that has its phases randomly
+    permuted in Fourier space.
+
+    Parameters
+    ----------
+    template: npt.NDArray[float]
+        input structure
+    seed: int, default 321
+        seed for random number generator for phase permutation
+
+    Returns
+    -------
+    result: npt.NDArray[float]
+        phase randomized version of the template
+    """
+    ft = np.fft.rfftn(template)
+    amplitude = np.abs(ft)
+
+    # permute the phases in flattened version of the array
+    phase = np.angle(ft).flatten()
+    grid = np.fft.ifftshift(
+        radial_reduced_grid(template.shape), axes=(0, 1)
+    ).flatten()
+    relevant_freqs = grid <= 1  # permute only up to Nyquist
+    noise = np.zeros_like(phase)
+    rng = np.random.default_rng(seed)
+    noise[relevant_freqs] = rng.permutation(phase[relevant_freqs])
+
+    # construct the new template
+    noise = np.reshape(noise, amplitude.shape)
+    result = np.fft.irfftn(
+        amplitude * np.exp(1j * noise), s=template.shape
+    )
+    return result

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from importlib import metadata
 from packaging import version
 import pathlib
 import os

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -147,6 +147,11 @@ class TestEntryPoints(unittest.TestCase):
         arguments['--low-pass'] = '50'
         start(arguments)
 
+        # phase randomization test
+        arguments = defaults.copy()
+        arguments['-r'] = ''
+        start(arguments)
+
         # test debug files
         arguments = defaults.copy()
         arguments['--log'] = 'debug'

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -91,5 +91,5 @@ class TestTemplate(unittest.TestCase):
             self.template, 11  # use default seed
         )
         diff = np.abs(randomized_seeded - randomized).sum()
-        self.assertEqual(diff, 0, msg='Different seed should return different '
-                                      'randomization')
+        self.assertNotEqual(diff, 0,
+                            msg='Different seed should return different randomization')

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from scipy.ndimage import center_of_mass
 from pytom_tm.template import (
-    phase_randomize_template
+    generate_template_from_map, phase_randomize_template
 )
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -86,3 +86,10 @@ class TestTemplate(unittest.TestCase):
             msg='After phase randomization the template should '
                 'no longer be equal to the input.'
         )
+
+        randomized_seeded = phase_randomize_template(
+            self.template, 11  # use default seed
+        )
+        diff = np.abs(randomized_seeded - randomized).sum()
+        self.assertEqual(diff, 0, msg='Different seed should return different '
+                                      'randomization')

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from scipy.ndimage import center_of_mass
 from pytom_tm.template import (
-    phase_randomize_template, generate_template_from_map
+    phase_randomize_template
 )
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,7 +1,9 @@
 import unittest
 import numpy as np
-from pytom_tm.template import generate_template_from_map
 from scipy.ndimage import center_of_mass
+from pytom_tm.template import (
+    phase_randomize_template, generate_template_from_map
+)
 
 
 class TestTemplate(unittest.TestCase):
@@ -73,3 +75,14 @@ class TestTemplate(unittest.TestCase):
         with self.assertNoLogs(level='WARNING'):
             _ = generate_template_from_map(self.template, 1., 1.,
                                            filter_to_resolution=2.5)
+
+    def test_phase_randomize_template(self):
+        randomized = phase_randomize_template(
+            self.template,  # use default seed
+        )
+        self.assertEqual(self.template.shape, randomized.shape)
+        self.assertGreater(
+            (self.template != randomized).sum(), 0,
+            msg='After phase randomization the template should '
+                'no longer be equal to the input.'
+        )

--- a/tests/test_template_matching.py
+++ b/tests/test_template_matching.py
@@ -122,6 +122,8 @@ class TestTM(unittest.TestCase):
         self.assertTrue(score_volume.max() > 0.99, msg='lcc max value lower than expected')
         self.assertEqual(angle_id, angle_volume[ind])
         self.assertSequenceEqual(loc, ind)
-        self.assertEqual(stats['search_space'], 256000000, msg='Search space should exactly equal this value')
-        self.assertAlmostEqual(stats['std'], 0.005187, places=5,
+        expected_search_space = len(self.angles) * self.volume.size
+        self.assertEqual(stats['search_space'], expected_search_space,
+                         msg='Search space should exactly equal this value')
+        self.assertAlmostEqual(stats['std'], 0.005187, places=4,
                                msg='Standard deviation of the search should be almost equal')

--- a/tests/test_template_matching.py
+++ b/tests/test_template_matching.py
@@ -92,3 +92,36 @@ class TestTM(unittest.TestCase):
         self.assertAlmostEqual(stats['std'], 0.005187, places=4,
                 msg='Standard deviation of the search should be almost equal')
 
+    def test_search_noise_correction(self):
+        angle_id = 100
+        rotation = self.angles[angle_id]
+        loc = (77, 26, 40)
+        self.volume[loc[0] - self.t_size // 2: loc[0] + self.t_size // 2,
+        loc[1] - self.t_size // 2: loc[1] + self.t_size // 2,
+        loc[2] - self.t_size // 2: loc[2] + self.t_size // 2] = vt.transform(
+            self.template,
+            rotation=rotation,
+            rotation_units='rad',
+            rotation_order='rzxz',
+            device='cpu'
+        )
+
+        tm = TemplateMatchingGPU(
+            0,
+            0,
+            self.volume,
+            self.template,
+            self.mask,
+            self.angles,
+            list(range(len(self.angles))),
+            noise_correction=True,
+        )
+        score_volume, angle_volume, stats = tm.run()
+
+        ind = np.unravel_index(score_volume.argmax(), self.volume.shape)
+        self.assertTrue(score_volume.max() > 0.99, msg='lcc max value lower than expected')
+        self.assertEqual(angle_id, angle_volume[ind])
+        self.assertSequenceEqual(loc, ind)
+        self.assertEqual(stats['search_space'], 256000000, msg='Search space should exactly equal this value')
+        self.assertAlmostEqual(stats['std'], 0.005187, places=5,
+                               msg='Standard deviation of the search should be almost equal')


### PR DESCRIPTION
This PR adds 'phase randomization', introduced by STOPGAP.

Explanation of what this is: The match_template command line got two additional arguments: one flag to activate this mode, another to set a seed for randomization. The seed is used to create a phase randomized version of the template, meaning the phases of the Fourier transform are randomly permuted (used often for FSC calculations). This second template is like a random noise object and is matched simultaneously with the original template. The score map of the noisy version is subtracted from the real one.

With the particle diameter updated and ctf input reworked, this is the last thing I really want to add in functionality-wise.

Once this one is merged, I would like make a PR to throw the code through ruff and maybe set up a pre-commit thingy. 

