### PR TITLE
Add tomogram mask option for template matching

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -865,6 +865,7 @@ def match_template(argv=None):
         search_x=args.search_x,
         search_y=args.search_y,
         search_z=args.search_z,
+        tomogram_mask=args.tomogram_mask,
         voxel_size=args.voxel_size_angstrom,
         low_pass=args.low_pass,
         high_pass=args.high_pass,

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -410,7 +410,7 @@ def extract_candidates(argv=None):
         "the tomogram. All values in the mask that are smaller or equal to 0 will be "
         "removed, all values larger than 0 are considered regions of interest. It can "
         "be used to extract annotations only within a specific cellular region."
-        "If the job was run with a tomogram mask, this will override that mask",
+        "If the job was run with a tomogram mask, this file will be used instead of the job mask",
     )
     parser.add_argument(
         "-n",

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -635,6 +635,15 @@ def match_template(argv=None):
         help="Start and end indices of the search along the z-axis, "
         "e.g. --search-x 30 230 ",
     )
+    volume_group.add_argument(
+        "--tomogram-mask",
+        type=pathlib.Path,
+        required=False,
+        action=CheckFileExists,
+        help="Here you can provide a mask for matching with dimensions equal to "
+        "the tomogram. If a subvolume only has values <= 0 for this mask it will be skipped.",
+    )
+
     filter_group = parser.add_argument_group("Filter control")
     filter_group.add_argument(
         "-a",

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -409,7 +409,8 @@ def extract_candidates(argv=None):
         help="Here you can provide a mask for the extraction with dimensions equal to "
         "the tomogram. All values in the mask that are smaller or equal to 0 will be "
         "removed, all values larger than 0 are considered regions of interest. It can "
-        "be used to extract annotations only within a specific cellular region.",
+        "be used to extract annotations only within a specific cellular region."
+        "If the job was run with a tomogram mask, this will override that mask",
     )
     parser.add_argument(
         "-n",

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -211,7 +211,7 @@ def extract_particles(
     if tomogram_mask is not None:
         slices = [
             slice(origin, origin + size)
-            for origin, size in zip(job.search_orgin, job.search_size)
+            for origin, size in zip(job.search_origin, job.search_size)
         ]
         tomogram_mask = tomogram_mask[*slices]
         # mask should be larger than zero in regions of interest!

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -164,7 +164,7 @@ def extract_particles(
         tune the number of false positives to be included for automated error function cut-off estimation:
         should be a float > 0
     tomogram_mask_path: Optional[pathlib.Path]
-        path to a tomographic binary mask for extraction
+        path to a tomographic binary mask for extraction, will override job.tomogram_mask
     tophat_filter: bool
         attempt to only select sharp peaks with the tophat filter
     create_plot: bool, default True
@@ -202,12 +202,19 @@ def extract_particles(
         )
 
     # apply tomogram mask if provided
+    tomogram_mask = None
     if tomogram_mask_path is not None:
-        tomogram_mask = read_mrc(tomogram_mask_path)[
-            job.search_origin[0] : job.search_origin[0] + job.search_size[0],
-            job.search_origin[1] : job.search_origin[1] + job.search_size[1],
-            job.search_origin[2] : job.search_origin[2] + job.search_size[2],
-        ]  # mask should be larger than zero in regions of interest!
+        tomogram_mask = read_mrc(tomogram_mask_path)
+    elif job.tomogram_mask is not None:
+        tomogram_mask = read_mrc(job.tomogram_mask)
+
+    if tomogram_mask is not None:
+        slices = [
+            slice(origin, origin + size)
+            for origin, size in zip(job.search_orgin, job.search_size)
+        ]
+        tomogram_mask = tomogram_mask[*slices]
+        # mask should be larger than zero in regions of interest!
         score_volume[tomogram_mask <= 0] = 0
 
     # mask edges of score volume

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -369,6 +369,12 @@ class TMJob:
 
         logging.debug(f"origin, size = {self.search_origin}, {self.search_size}")
         self.tomogram_mask = tomogram_mask
+        if tomogram_mask is not None:
+            temp = read_mrc(tomogram_mask)
+            if np.all(temp <= 0):
+                raise ValueError(
+                    f"No values larger than 0 found in the template mask: {tomogram_mask}"
+                )
 
         self.whole_start = None
         # For the main job these are always [0,0,0] and self.search_size, for sub_jobs these will differ from
@@ -560,11 +566,8 @@ class TMJob:
 
         search_size = self.search_size
         if self.tomogram_mask is not None:
+            # This should have some positve values after the check in the __init__
             tomogram_mask = read_mrc(self.tomogram_mask)
-            if np.all(tomogram_mask <= 0):
-                raise TMJobError(
-                    f"No positive values in tomogram mask: {self.tomogram_mask}"
-                )
         else:
             tomogram_mask = None
         # shape of template for overhang

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -373,7 +373,7 @@ class TMJob:
             temp = read_mrc(tomogram_mask)
             if np.all(temp <= 0):
                 raise ValueError(
-                    f"No values larger than 0 found in the template mask: {tomogram_mask}"
+                    f"No values larger than 0 found in the tomogram mask: {tomogram_mask}"
                 )
 
         self.whole_start = None

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -17,5 +17,6 @@ class TestExtract(unittest.TestCase):
             tophat_mask.dtype, bool, msg="predicted tophat mask should be boolean"
         )
 
-    def test_extract_job_with_tomogram_mask(self):
-        self.fail()
+    # part of the extraction test in test_tmjob.py
+    # def test_extract_job_with_tomogram_mask(self):
+    #    pass

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -16,3 +16,6 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(
             tophat_mask.dtype, bool, msg="predicted tophat mask should be boolean"
         )
+
+    def test_extract_job_with_tomogram_mask(self):
+        self.fail()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -492,12 +492,12 @@ class TestTMJob(unittest.TestCase):
         job = self.job.copy()
         job.tomogram_mask = TEST_EXTRACTION_MASK_INSIDE
         job.split_volume_search((10, 10, 10))
-        self.assertLess(len(job.subjobs), 10 * 10 * 10)
+        self.assertLess(len(job.sub_jobs), 10 * 10 * 10)
 
     def test_splitting_with_broken_tomogram_mask(self):
         job = self.job.copy()
         job.tomogram_mask = TEST_BROKEN_TOMOGRAM_MASK
-        with self.assertRaisesRegex(TMJobError, TEST_BROKEN_TOMOGRAM_MASK):
+        with self.assertRaisesRegex(TMJobError, str(TEST_BROKEN_TOMOGRAM_MASK)):
             job.split_volume_search((2, 2, 2))
 
     def test_splitting_with_offsets(self):

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -481,6 +481,14 @@ class TestTMJob(unittest.TestCase):
             "almost identical.",
         )
 
+    def test_splitting_with_tomogram_mask(self):
+        # TODO: add test
+        self.fail()
+
+    def test_splitting_with_broken_tomogram_mask(self):
+        # TODO: add test
+        self.fail()
+
     def test_splitting_with_offsets(self):
         # check if subjobs have correct offsets for the main job, the last sub job will have the largest errors
         job = TMJob(

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -238,6 +238,20 @@ class TestTMJob(unittest.TestCase):
                 voxel_size=1.0,
             )
 
+        # Test broken template mask
+        with self.assertRaisesRegex(ValueError, str(TEST_BROKEN_TOMOGRAM_MASK)):
+            TMJob(
+                "0",
+                10,
+                TEST_TOMOGRAM,
+                TEST_TEMPLATE,
+                TEST_MASK,
+                TEST_DATA_DIR,
+                angle_increment=ANGULAR_SEARCH,
+                voxel_size=1.0,
+                template_mask=TEST_BROKEN_TOMOGRAM_MASK,
+            )
+
     def test_tm_job_copy(self):
         copy = self.job.copy()
         self.assertIsNot(
@@ -492,12 +506,6 @@ class TestTMJob(unittest.TestCase):
         job.tomogram_mask = TEST_EXTRACTION_MASK_INSIDE
         job.split_volume_search((10, 10, 10))
         self.assertLess(len(job.sub_jobs), 10 * 10 * 10)
-
-    def test_splitting_with_broken_tomogram_mask(self):
-        job = self.job.copy()
-        job.tomogram_mask = TEST_BROKEN_TOMOGRAM_MASK
-        with self.assertRaisesRegex(TMJobError, str(TEST_BROKEN_TOMOGRAM_MASK)):
-            job.split_volume_search((2, 2, 2))
 
     def test_splitting_with_offsets(self):
         # check if subjobs have correct offsets for the main job, the last sub job will have the largest errors

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -87,7 +87,6 @@ class TestTMJob(unittest.TestCase):
             overwrite=True,
         )
         write_mrc(TEST_TOMOGRAM, volume, 1.0)
-        #
 
         # do a run without splitting to compare against
         job = TMJob(

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -249,7 +249,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_DATA_DIR,
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
-                template_mask=TEST_BROKEN_TOMOGRAM_MASK,
+                tomogram_mask=TEST_BROKEN_TOMOGRAM_MASK,
             )
 
     def test_tm_job_copy(self):


### PR DESCRIPTION
closes #54 

It will use the same definition as for the extraction `(any point <=0 is skipped)` but will initially only skip subvolumes where the complete mask is <= 0

For the extraction, it will use `job.tomogram_mask` as well, which can be overridden by giving a separate tomogram_mask in the entry point

- [x] add option to entry point
- [x] add code logic to tmjob
- [x] add extra code logic to extract
- [x] add tests