### PR TITLE
add tutorial test yml

### DIFF
--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -1,0 +1,61 @@
+name: Test Tutorial
+# following example: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  workflow_run:
+    workflows: ["Unit tests"]
+    types:
+      - completed
+
+jobs:
+  test-tutorial:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, linux, x64, gpu]
+    container:
+      image: continuumio/miniconda3
+      options: --runtime=nvidia --gpus all
+    permissions:
+      # Read the action that triggered this one
+      actions: read
+      # Allow to write check runs
+      checks: write
+      # Read and update commit statuses
+      statuses: write
+    steps:
+      - name: Pull code
+        uses: actions/checkout@v4
+        with:
+          repository: github.event.workflow_run.head_repository
+          ref: github.event.workflow_run.head_sha
+      - name: Pull wiki
+        uses: actions/checkout@v4
+        with:
+          # Only check the wiki of the calling repo
+          repository: ${{github.repository}}.wiki 
+          path: wiki
+      - name: Install dependencies, code, and list everything
+        run: |
+          conda install -y -c conda-forge python=3 cupy cuda-version=11.8
+          python -m pip install coverage mdextractor #mdextractor is new and might need to be replaced later
+          python -m pip install .[dev]
+          conda list
+      - name: Grab files needed for tests
+        run: |
+          mkdir wiki/dataset
+          mkdir wiki/templates
+          cd wiki/templates
+          cp ../data/6qzp_60S wiki/templates/
+          curl https://files.wwpdb.org/pub/emdb/structures/EMD-2938/map/emd_2938.map.gz -o emd_2938.map.gz
+          gunzip emd_2938.map.gz
+          mv emd_2938.map emd_2938.mrc
+          cd ../dataset
+          curl -L -O -J -H "X-Dataverse-key:${{ secrets.DATAVERSE_API_TOKEN }}" https://dataverse.nl/api/access/datafiles/384731,384724,384706,384718
+          unzip dataverse_files.zip
+          mv tutorial/* .
+          cd ../
+      - name: Run Tutorial test
+        run: |
+          # Hardcode the conversion line
+          for x in dataset/*.mrc; do python -c "import mrcfile; mrc = mrcfile.mmap('$x', 'r+'); mrc.voxel_size = 13.79"; done
+          python tests/test_tutorial.py


### PR DESCRIPTION
closes #148 

For now this does not include coverage
It uses repo secrets for pulling from dataverse, which means it has to be spawned like the coverage comment workflow

It walks through the tutorial file, grabs all code blocks and executes them if they start with `*.py`