### PR TITLE
fix defocus help unit

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -713,9 +713,9 @@ def match_template(argv=None):
         required=False,
         action=ParseDefocus,
         help="Here you can provide an IMOD defocus (.defocus) file (version 2 or 3) "
-        ", a text (.txt) file with a single defocus value per line (in nm), "
+        ", a text (.txt) file with a single defocus value per line (in μm), "
         "or a single "
-        "defocus value (in nm). "
+        "defocus value (in μm). "
         "The value(s), together with the other ctf "
         "parameters (amplitude contrast, voltage, spherical abberation), "
         "will be used to create a 3D CTF weighting function. IMPORTANT: if "


### PR DESCRIPTION
@frozenfas noticed an inconsistent unit in the help message of the defocus cli.
This sets it to the correct one instead (`nm` to `μm`)