### PR TITLE
add check on tomo mask shape

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -436,7 +436,7 @@ def extract_candidates(argv=None):
         type=pathlib.Path,
         required=False,
         action=CheckFileExists,
-        help="Here you can provide a mask for the extraction with dimensions equal to "
+        help="Here you can provide a mask for the extraction with dimensions (in pixels) equal to "
         "the tomogram. All values in the mask that are smaller or equal to 0 will be "
         "removed, all values larger than 0 are considered regions of interest. It can "
         "be used to extract annotations only within a specific cellular region."
@@ -687,7 +687,7 @@ def match_template(argv=None):
         type=pathlib.Path,
         required=False,
         action=CheckFileExists,
-        help="Here you can provide a mask for matching with dimensions equal to "
+        help="Here you can provide a mask for matching with dimensions (in pixels) equal to "
         "the tomogram. If a subvolume only has values <= 0 for this mask it will be skipped.",
     )
 

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -216,6 +216,11 @@ def extract_particles(
         tomogram_mask = read_mrc(job.tomogram_mask)
 
     if tomogram_mask is not None:
+        if tomogram_mask.shape != job.tomo_shape:
+            raise ValueError(
+                "Tomogram mask does not have the same number of pixels as the tomogram.\n"
+                f"Tomogram mask shape: {tomogram_mask.shape}, tomogram shape: {job.tomo_shape}"
+            )
         slices = [
             slice(origin, origin + size)
             for origin, size in zip(job.search_origin, job.search_size)

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -374,7 +374,7 @@ class TMJob:
             if temp.shape != self.tomo_shape:
                 raise ValueError(
                     "Tomogram mask does not have the same number of pixels as the tomogram.\n"
-                    "Tomogram mask shape: {temp.shape}, tomogram shape: {self.tomo_shape}"
+                    f"Tomogram mask shape: {temp.shape}, tomogram shape: {self.tomo_shape}"
                 )
             if np.all(temp <= 0):
                 raise ValueError(

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -371,6 +371,11 @@ class TMJob:
         self.tomogram_mask = tomogram_mask
         if tomogram_mask is not None:
             temp = read_mrc(tomogram_mask)
+            if temp.shape != self.tomo_shape:
+                raise ValueError(
+                    "Tomogram mask does not have the same number of pixels as the tomogram.\n"
+                    "Tomogram mask shape: {temp.shape}, tomogram shape: {self.tomo_shape}"
+                )
             if np.all(temp <= 0):
                 raise ValueError(
                     f"No values larger than 0 found in the tomogram mask: {tomogram_mask}"

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -708,7 +708,7 @@ class TestTMJob(unittest.TestCase):
                 job,
                 5,
                 100,
-                tomogram_mask=TEST_WRONG_SIZE_TOMO_MASK,
+                tomogram_mask_path=TEST_WRONG_SIZE_TOMO_MASK,
                 create_plot=False,
             )
 


### PR DESCRIPTION
closes #194 
(the part that the tm-job should error out if the mask is the wrong size)

Also adds the same check to the extraction job

- [X] add checks to catch mismatch between tomo mask and tomogram in tmjob
- [x] as above for extraction
- [x] alter tooltips to mention number of pixels
- [x] add tests