### PR TITLE
Fix relion5 compat

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -548,7 +548,9 @@ def extract_candidates(argv=None):
 
     # write out as a RELION type starfile
     starfile.write(
-        df, job.output_dir.joinpath(f"{job.tomo_id}_particles.star"), overwrite=True
+        {"particles": df},
+        job.output_dir.joinpath(f"{job.tomo_id}_particles.star"),
+        overwrite=True,
     )
 
 
@@ -1007,5 +1009,7 @@ def merge_stars(argv=None):
     dataframes = [starfile.read(f) for f in files]
 
     starfile.write(
-        pd.concat(dataframes, ignore_index=True), args.output_file, overwrite=True
+        {"particles": pd.concat(dataframes, ignore_index=True)},
+        args.output_file,
+        overwrite=True,
     )

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -346,6 +346,7 @@ def extract_particles(
             "rlnCoordinateY": "rlnCenteredCoordinateYAngst",
             "rlnCoordinateZ": "rlnCenteredCoordinateZAngst",
             "rlnMicrographName": "rlnTomoName",
+            "rlnDetectorPixelSize": "rlnTomoTiltSeriesPixelSize",
         }
         output = output.rename(columns=column_change)
 

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -631,6 +631,7 @@ class TestTMJob(unittest.TestCase):
             "rlnCenteredCoordinateYAngst",
             "rlnCenteredCoordinateZAngst",
             "rlnTomoName",
+            "rlnTomoTiltSeriesPixelSize",
         ):
             self.assertTrue(
                 column in df_rel5.columns,


### PR DESCRIPTION
Fixes some of the problems addressed in #214 .

* starfiles are now written with `data_particles` instead of `data_` by providing a block name to the starfile package
* a column name in relion5 compat mode has been updated from `rlnDetectorPixelSize` to `rlnTomoTiltSeriesPixelSize`