### PR TITLE
set to 1.12 instead of 1.12.1

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m twine check dist/*
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12.1
+        uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Download conda dependencies 


### PR DESCRIPTION
I think I made the mistake of pointing it to 1.12.1 while it can only point to branches of the github action repo. Therefore 1.12 should be valid.