### PR TITLE
Restructure release

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -8,15 +8,13 @@ on:
       - published
 
 # Following: https://docs.pypi.org/trusted-publishers/using-a-publisher/
+# and https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 jobs:
-  publish_release:
+  build-release:
     runs-on: [self-hosted, linux, x64, gpu]
     container:
       image: continuumio/miniconda3
       options: --runtime=nvidia --gpus all
-    # environment: release
-    permissions:
-      id-token: write
     steps:
       - name: Pull code
         uses: actions/checkout@v4
@@ -29,17 +27,38 @@ jobs:
       - name: twine check distributions
         run: |
           python -m twine check dist/*
-      - name: debug code 
-        run: |
-          ls /
-      - name: debug part 2
-        run: |
-          ls -R /__w/
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
         with:
+          name: match-pick-distributions
+          path: dist/
+  
+  publish-to-testpypi:
+    name: publish to test-pypi
+    needs: build-release
+    runs-on: ubuntu-latest
+    #environment: release
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package distributions to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
           repository-url: https://test.pypi.org/legacy/
-          attestations: false
+  
+  test-testpypi:
+     name: test testpypi deployment
+     needs: publish-to-testpypi
+     runs-on: [self-hosted, linux, x64, gpu]
+     container:
+       image: continuumio/miniconda3
+       options: --runtime=nvidia --gpus all
+     steps:
       - name: Download conda dependencies 
         run: |
           conda install -y -c conda-forge python=3 cupy cuda-version=11.8
@@ -49,7 +68,21 @@ jobs:
       - name: Run tests on the installed package
         run: |
           python -m unittest discover tests/
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-           attestations: false
+  
+  publish-to-pypi:
+    name: publish to pypi
+    needs: [build-release, test-testpypi]
+    runs-on: ubuntu-latest
+    #environment: release
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+            
+      

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: continuumio/miniconda3
       options: --runtime=nvidia --gpus all
-    environment: release
+    # environment: release
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -31,10 +31,10 @@ jobs:
           python -m twine check dist/*
       - name: debug code 
         run: |
-          ls /home
+          ls /
       - name: debug part 2
         run: |
-          ls /__w/_actions
+          ls -R /__w/
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -26,8 +26,12 @@ jobs:
       - name: twine check distributions
         run: |
           python -m twine check dist/*
+      - name: debug code 
+        run: |
+          ls /home/githubrunner/actions-runner/_work/_actions/
+          ls /__w/_actions
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.11  # temporary workaround for issue #236
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           attestations: false
@@ -41,6 +45,6 @@ jobs:
         run: |
           python -m unittest discover tests/
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.11  # temporary workaround for issue #236
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
            attestations: false

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -31,7 +31,7 @@ jobs:
           python -m twine check dist/*
       - name: debug code 
         run: |
-          ls /home/githubrunner/actions-runner/_work/_actions/
+          ls /home
           ls /__w/_actions
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,8 +1,5 @@
 name: "PyPI release"
 on:
-  push:
-    branches:
-      - sroet-patch-1
   release:
     types:
       - published
@@ -37,7 +34,7 @@ jobs:
     name: publish to test-pypi
     needs: build-release
     runs-on: ubuntu-latest
-    #environment: release
+    environment: release
     permissions:
       id-token: write
     steps:
@@ -73,7 +70,7 @@ jobs:
     name: publish to pypi
     needs: [build-release, test-testpypi]
     runs-on: ubuntu-latest
-    #environment: release
+    environment: release
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
+        name: match-pick-distributions
         path: dist/
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -80,7 +80,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
+        name: match-pick-distributions
         path: dist/
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,5 +1,8 @@
 name: "PyPI release"
 on:
+  push:
+    branches:
+      - sroet-patch-1
   release:
     types:
       - published

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -32,6 +32,8 @@ jobs:
       - name: debug code 
         run: |
           ls /home
+      - name: debug part 2
+        run: |
           ls /__w/_actions
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Install from testPyPi
         run: |
           python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pytom-match-pick[plotting]
+      - name: Pull test code
+        uses: actions/checkout@v4
       - name: Run tests on the installed package
         run: |
           python -m unittest discover tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.7.8"
+version = "0.7.9"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Following the debugging done in #241, I decided to restructure the release following current best practices.

The workflow now has 4 jobs each depending on the previous one to succeed, with the type of runner in `[]`:
1) [self-hosted] build the package and test with `twine check`, upload artifact
2) [github] upload the distribution to testPyPI
3) [self-hosted] pull the latest version from testPyPI and run the test suite
4) [github] upload the distribution to PyPI