### PR TITLE
new ruff version

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -76,7 +76,7 @@ def generate_template_from_map(
         logging.debug(
             f"center of mass, before was "
             f"{np.round(input_center_of_mass, 2)} "
-            f"and after {np.round(center_of_mass(input_map ** 2), 2)}"
+            f"and after {np.round(center_of_mass(input_map**2), 2)}"
         )
 
     # extend volume to the desired output size before applying convolutions!

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -179,7 +179,7 @@ def _determine_1D_fft_splits(
         return [((0, length), (0, length))]
     if splits > length:
         warnings.warn(
-            "More splits than pixels where asked, will default to 1 split per pixel",
+            "More splits than pixels were asked, will default to 1 split per pixel",
             RuntimeWarning,
         )
         splits = length

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -179,7 +179,7 @@ def _determine_1D_fft_splits(
         return [((0, length), (0, length))]
     if splits > length:
         warnings.warn(
-            "More splits than pixels where asked," " will default to 1 split per pixel",
+            "More splits than pixels where asked, will default to 1 split per pixel",
             RuntimeWarning,
         )
         splits = length

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -143,7 +143,7 @@ class TestEntryPoints(unittest.TestCase):
         start(arguments)
 
         with self.assertRaises(
-            ValueError, msg="Missing CTF params should produce " "error"
+            ValueError, msg="Missing CTF params should produce error"
         ):
             arguments = defaults.copy()
             arguments.pop("--voltage")
@@ -151,7 +151,7 @@ class TestEntryPoints(unittest.TestCase):
 
         # test angular search and particle diameter options
         with self.assertRaises(
-            ValueError, msg="Missing angular search should raise " "an error."
+            ValueError, msg="Missing angular search should raise an error."
         ):
             arguments = defaults.copy()
             arguments.pop("--angular-search")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -41,7 +41,7 @@ class TestTemplate(unittest.TestCase):
         square_sum = np.square(new_template - self.template).sum()
         self.assertTrue(
             square_sum < 10,
-            msg="Template should not change strongly " "without recentering.",
+            msg="Template should not change strongly without recentering.",
         )
         new_template = generate_template_from_map(
             self.template,

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -655,8 +655,7 @@ class TestTMJob(unittest.TestCase):
         self.assertEqual(
             diff,
             0,
-            msg="relion5 compat mode should return a centered "
-            "location of the object",
+            msg="relion5 compat mode should return a centered location of the object",
         )
         self.assertNotIn("rec_", df_rel5["rlnTomoName"][0])
 


### PR DESCRIPTION
Currently our unit tests are failing because ruff changed some formatting rules around. This updates our files to be ruff compliant. Also updates a typo ('where asked' `->` 'were asked')