### PR TITLE
Change extract radius to particle diameter for consistency

### DIFF
--- a/docs/tutorials/Tutorial.md
+++ b/docs/tutorials/Tutorial.md
@@ -157,8 +157,7 @@ template matching results.
 ``` bash
 pytom_extract_candidates.py \
  -j results_80S/tomo200528_107_job.json \
- -n 200 \
- -r 5
+ -n 200
 ```
 
 This produces the following two files:

--- a/docs/tutorials/Tutorial.md
+++ b/docs/tutorials/Tutorial.md
@@ -168,7 +168,7 @@ This produces the following two files:
 
 pytom-match-pick has a default cut-off estimation 
 built-in and only extracts results above this threshold, but up to the limit of 200 
-that was specified (`-n 200`). In this we get 169 annotations. This program also by 
+that was specified (`-n 200`). In this we get 164 annotations. This program also by 
 default generates a plot that visualizes the estimated background and annotations. 
 
 <figure markdown="span">
@@ -327,7 +327,7 @@ pytom_extract_candidates.py \
 
 Running the extraction with this option, produces a second plot that 
 can be inspected in the folder (`results_60S/tomo200528_107_tophat_filter.svg`). The 
-number of annotations went down from 121 to 69, so we definitely lost some hits. 
+number of annotations went down from 108 to 69, so we definitely lost some hits. 
 
 <figure markdown="span">
   ![part1_roc](images/2_tomo200528_107_slice101_blik_tophat.png){ width="400" }

--- a/docs/tutorials/Tutorial.md
+++ b/docs/tutorials/Tutorial.md
@@ -292,8 +292,7 @@ Similar to part 1, we extract particles and look at the histogram of extracted s
 ``` bash
 pytom_extract_candidates.py \
  -j results_60S/tomo200528_107_job.json \
- -n 200 \
- -r 5
+ -n 200
 ```
 
 <figure markdown="span">
@@ -324,7 +323,6 @@ tophat-transform constraint to hopefully remove more false positives:
 pytom_extract_candidates.py \
  -j results_60S/tomo200528_107_job.json \
  -n 200 \
- -r 5 \
  --tophat-filter
 ```
 
@@ -352,7 +350,6 @@ how to use it here:
 pytom_estimate_roc.py \
  -j results_80S/tomo200528_100_job.json \
  -n 800 \
- -r 8 \
  --bins 16 \
  --crop-plot  > results_80S/tomo200528_100_roc.log
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.7.11"
+version = "0.8.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -483,13 +483,18 @@ def extract_candidates(argv=None):
         "the cut-off more restrictive.",
     )
     parser.add_argument(
-        "-r",
-        "--radius-px",
-        type=int,
-        required=True,
+        "--particle-diameter",
+        type=float,
+        required=False,
         action=LargerThanZero,
-        help="Particle radius in pixels in the tomogram. It is used during extraction "
-        "to remove areas around peaks preventing double extraction.",
+        help="Particle diameter of the template in Angstrom. It is used during "
+        "extraction to remove areas around peaks to prevent double extraction. "
+        "If not previously specified, this option is required. If "
+        "specified in pytom_match_template, this is optional and "
+        "can be used to overwrite it, which might be relevant for strongly "
+        "elongated particles--where the angular sampling should be "
+        "determined using its long axis but the extraction mask should use its "
+        "short axis.",
     )
     parser.add_argument(
         "-c",

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -318,13 +318,18 @@ def estimate_roc(argv=None):
         "is to multiply the expected number of particles by 3.",
     )
     parser.add_argument(
-        "-r",
-        "--radius-px",
-        type=int,
-        required=True,
+        "--particle-diameter",
+        type=float,
+        required=False,
         action=LargerThanZero,
-        help="Particle radius in pixels in the tomogram. It is used during extraction "
-        "to remove areas around peaks preventing double extraction.",
+        help="Particle diameter of the template in Angstrom. It is used during "
+        "extraction to remove areas around peaks to prevent double extraction. "
+        "If not previously specified, this option is required. If "
+        "specified in pytom_match_template, this is optional and "
+        "can be used to overwrite it, which might be relevant for strongly "
+        "elongated particles--where the angular sampling should be "
+        "determined using its long axis but the extraction mask should use its "
+        "short axis.",
     )
     parser.add_argument(
         "--bins",
@@ -390,8 +395,8 @@ def estimate_roc(argv=None):
     # Set cut off to -1 to ensure the number of particles gets extracted
     _, lcc_max_values = extract_particles(
         template_matching_job,
-        args.radius_px,
         args.number_of_particles,
+        particle_diameter=args.particle_diameter,
         cut_off=0,
         create_plot=False,
         ignore_tomogram_mask=args.ignore_tomogram_mask,
@@ -567,8 +572,8 @@ def extract_candidates(argv=None):
     job = load_json_to_tmjob(args.job_file)
     df, _ = extract_particles(
         job,
-        args.radius_px,
         args.number_of_particles,
+        particle_diameter=args.particle_diameter,
         cut_off=args.cut_off,
         n_false_positives=args.number_of_false_positives,
         tomogram_mask_path=args.tomogram_mask,

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -150,8 +150,8 @@ def predict_tophat_mask(
 
 def extract_particles(
     job: TMJob,
-    particle_radius_px: int,
     n_particles: int,
+    particle_diameter: float | None = None,
     cut_off: float | None = None,
     n_false_positives: float = 1.0,
     tomogram_mask_path: pathlib.Path | None = None,
@@ -168,10 +168,10 @@ def extract_particles(
     ----------
     job: pytom_tm.tmjob.TMJob
         template matching job to annotate particles from
-    particle_radius_px: int
-        particle radius to remove peaks with after a score has been annotated
     n_particles: int
         maximum number of particles to extract
+    particle_diameter: Optional[float]
+        particle diameter to remove peaks with after a score has been annotated
     cut_off: Optional[float]
         manually override the automated score cut-off estimation, value between 0 and 1
     n_false_positives: float, default 1.0
@@ -249,6 +249,22 @@ def extract_particles(
         tomogram_mask = tomogram_mask[*slices]
         # mask should be larger than zero in regions of interest!
         score_volume[tomogram_mask <= 0] = 0
+
+    if particle_diameter is not None:
+        particle_radius_px = int((particle_diameter / 2) / job.voxel_size)
+    elif job.particle_diameter is not None:
+        particle_radius_px = int((job.particle_diameter / 2) / job.voxel_size)
+        logging.info(
+            "No particle diameter was provided, so using the diameter "
+            "specified previously to mask out areas around peaks. Take care for "
+            "elongated particles (i.e. very non-spherical) as it might remove "
+            "annotations when they arrange parallel to each other and close together."
+        )
+    else:
+        raise ValueError(
+            "You need to specify a particle diameter to mask out areas around each "
+            "peak during extraction!"
+        )
 
     # mask edges of score volume
     score_volume[0:particle_radius_px, :, :] = 0

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -257,8 +257,8 @@ def extract_particles(
         logging.info(
             "No particle diameter was provided, so using the diameter "
             "specified previously to mask out areas around peaks. Take care for "
-            "elongated particles (i.e. very non-spherical) as it might remove "
-            "annotations when they arrange parallel to each other and close together."
+            "strongly elongated particles as it might prevent correct "
+            "annotation when they arrange parallel to each other and close together."
         )
     else:
         raise ValueError(

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -430,7 +430,9 @@ class TestTMJob(unittest.TestCase):
             scores, angles = job.start_job(0, return_volumes=True)
             write_mrc(data_dir / "tomogram_scores.mrc", scores, job.voxel_size)
             write_mrc(data_dir / "tomogram_angles.mrc", angles, job.voxel_size)
-            df, scores = extract_particles(job, 5, 100, create_plot=False)
+            df, scores = extract_particles(
+                job, 100, particle_diameter=10, create_plot=False
+            )
             self.assertNotEqual(
                 len(scores), 0, msg="Here we expect to get some annotations."
             )
@@ -628,14 +630,19 @@ class TestTMJob(unittest.TestCase):
         )
 
         # extract particles after running the job
-        df, scores = extract_particles(self.job, 5, 100, create_plot=False)
+        df, scores = extract_particles(
+            self.job, 100, particle_diameter=5, create_plot=False
+        )
         self.assertNotEqual(
             len(scores), 0, msg="Here we expect to get some annotations."
         )
 
+        with self.assertRaisesRegex(ValueError, "particle diameter"):
+            _ = extract_particles(self.job, 100, create_plot=False)
+
         # extract particles in relion5 style
         df_rel5, scores = extract_particles(
-            self.job, 5, 100, create_plot=False, relion5_compat=True
+            self.job, 100, particle_diameter=10, create_plot=False, relion5_compat=True
         )
         for column in (
             "rlnCenteredCoordinateXAngst",
@@ -678,8 +685,8 @@ class TestTMJob(unittest.TestCase):
         job.tomogram_mask = TEST_EXTRACTION_MASK_OUTSIDE
         df, scores = extract_particles(
             job,
-            5,
             100,
+            particle_diameter=10,
             create_plot=False,
         )
         self.assertEqual(
@@ -693,8 +700,8 @@ class TestTMJob(unittest.TestCase):
         with self.assertLogs(level="WARNING") as cm:
             df, scores = extract_particles(
                 job,
-                5,
                 100,
+                particle_diameter=10,
                 tomogram_mask_path=TEST_EXTRACTION_MASK_OUTSIDE,
                 create_plot=False,
                 ignore_tomogram_mask=True,
@@ -716,8 +723,8 @@ class TestTMJob(unittest.TestCase):
         # and should override the one now attached to the job
         df, scores = extract_particles(
             job,
-            5,
             100,
+            particle_diameter=5,
             tomogram_mask_path=TEST_EXTRACTION_MASK_INSIDE,
             create_plot=False,
         )
@@ -732,8 +739,8 @@ class TestTMJob(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, str(TOMO_SHAPE)):
             _, _ = extract_particles(
                 job,
-                5,
                 100,
+                particle_diameter=5,
                 tomogram_mask_path=TEST_WRONG_SIZE_TOMO_MASK,
                 create_plot=False,
             )
@@ -752,8 +759,8 @@ class TestTMJob(unittest.TestCase):
         # Test exraction with tophat filter and plotting
         df, scores = extract_particles(
             job,
-            5,
             100,
+            particle_diameter=5,
             tomogram_mask_path=TEST_EXTRACTION_MASK_INSIDE,
             create_plot=True,
             tophat_filter=True,

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -631,7 +631,7 @@ class TestTMJob(unittest.TestCase):
 
         # extract particles after running the job
         df, scores = extract_particles(
-            self.job, 100, particle_diameter=5, create_plot=False
+            self.job, 100, particle_diameter=10, create_plot=False
         )
         self.assertNotEqual(
             len(scores), 0, msg="Here we expect to get some annotations."
@@ -639,6 +639,11 @@ class TestTMJob(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "particle diameter"):
             _ = extract_particles(self.job, 100, create_plot=False)
+        job = self.job.copy()
+        job.particle_diameter = 10
+        with self.assertLogs(level="INFO") as cm:
+            _ = extract_particles(job, 100, create_plot=False)
+        self.assertIn("No particle diameter was provided,", "".join(cm.output))
 
         # extract particles in relion5 style
         df_rel5, scores = extract_particles(


### PR DESCRIPTION
This makes the extract radius parameter easier to interpret and prevents redundancy. Closes #262

