### PR TITLE
Fix auto compilation of docs

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -34,7 +34,7 @@ code = ("""
 ---8<--- "entry_points.py:create_template_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'default=', 'type=', 'error_on_multi_column='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)


### PR DESCRIPTION
After merge of #276 the autogeneration of the docs are failing with:
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/markdown_exec/_internal/formatters/python.py", line 71, in _run_python
    exec_python(code, code_block_id, exec_globals)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/markdown_exec/_internal/formatters/_exec_python.py", line 8, in exec_python
    exec(compiled, exec_globals)  # noqa: S102
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "<code block: n3>", line 357, in <module>
    exec(cleaned_code)
    ~~~~^^^^^^^^^^^^^^
  File "<string>", line 121, in <module>
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/argparse.py", line 1465, in add_argument
    action = action_class(**kwargs)
TypeError: _StoreAction.__init__() got an unexpected keyword argument 'error_on_multi_column'
```

This should solve that

