### PR TITLE
add CODEOWNERS file to harden .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# HARDEN .github directory (from the root of the repo) to only be altered by maintainers
+# HARDEN .github directory (from the root of the repo) to only be altered after review by maintainers
 /.github/ @SBC-Utrecht/maintainers


### PR DESCRIPTION
closes #286 

This makes it so that only people in the @SBC-Utrecht/maintainers team can alter stuff in the `.github` folder and subdirectories (including this file and any of the workflows)

For reference of this file, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners