### PR TITLE
drop python 3.10

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,3 +53,21 @@ jobs:
         with: 
           path: coverage.*
           name: coverage
+  test_suite_min_py_version:
+    runs-on: [self-hosted, linux, x64, gpu]
+    container:
+      image: continuumio/miniconda3
+      options: --runtime=nvidia --gpus all
+    steps:
+      - name: Pull code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          conda install -y -c conda-forge python=3.11 cupy cuda-version=11.8 gcc #gcc only needed until healpix releases under numpy>2
+      - name: Install base dev code and list dependencies 
+        run: |
+          python -m pip install -e .[dev]
+          conda list
+      - name: Run tests
+        run: |
+          python -m unittest discover tests/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
           conda install -y -c conda-forge python=3.11 cupy cuda-version=11.8 gcc #gcc only needed until healpix releases under numpy>2
       - name: Install base dev code and list dependencies 
         run: |
-          python -m pip install -e .[dev]
+          python -m pip install .
           conda list
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Typing :: Typed"
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 dependencies = [
     "numpy",
     "cupy!=13.0.*", #see https://github.com/SBC-Utrecht/pytom-match-pick/issues/106


### PR DESCRIPTION
According to ruff, we already use code that will break on python 3.10:
```
src/pytom_tm/extract.py:250:39: SyntaxError: Cannot use star expression in index on Python 3.10 (syntax was added in Python 3.11)
    |
248 |             for origin, size in zip(job.search_origin, job.search_size)
249 |         ]
250 |         tomogram_mask = tomogram_mask[*slices]
    |                                       ^^^^^^^
251 |
252 |         # If tomogram_mask is stored as signed bytes we need to convert it to unsigned:
    |

src/pytom_tm/tmjob.py:715:41: SyntaxError: Cannot use star expression in index on Python 3.10 (syntax was added in Python 3.11)
    |
713 |                     for origin, step in zip(whole_start, sub_step)
714 |                 ]
715 |                 if np.all(tomogram_mask[*slices] <= 0):
    |                                         ^^^^^^^
716 |                     # No non-masked unique data-points, skipping
717 |                     continue
    |

Found 2 errors.
Error: Process completed with exit code 1.
```

python 3.10 is also out of [SPEC0](https://scientific-python.org/specs/spec-0000/) and [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) support window, so I think it is fair to drop. 
We should also explicitly test our minimal python version to catch these things on the implementation side, so added that to the test suite