### PR TITLE
actually use normalise function from correlation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.9.0"
+version = "0.10.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/correlation.py
+++ b/src/pytom_tm/correlation.py
@@ -103,12 +103,10 @@ def normalise(
 def normalised_cross_correlation(
     data1: npt.NDArray[float] | cpt.NDArray[float],
     data2: npt.NDArray[float] | cpt.NDArray[float],
-    mask: npt.NDArray[float] | cpt.NDArray[float] | None = None,
 ) -> float | cpt.NDArray[float]:
-    """Calculate normalised cross correlation between two arrays. Optionally only in a
-    masked region.
+    """Calculate normalised cross correlation between two arrays.
 
-    data1, data2, and mask can be cupy or numpy arrays.
+    data1, and data2 can be cupy or numpy arrays.
 
     Parameters
     ----------
@@ -116,18 +114,11 @@ def normalised_cross_correlation(
         first array for correlation
     data2: Union[npt.NDArray[float], cpt.NDArray[float]]
         second array for correlation
-    mask: Optional[Union[npt.NDArray[float], cpt.NDArray[float]]], default None
-        optional mask to calculate the correlation under
 
     Returns
     -------
     output: Union[float, cpt.NDArray[float]]
         normalised cross correlation between the arrays
     """
-    if mask is None:
-        output = (normalise(data1) * normalise(data2)).sum() / data1.size
-    else:
-        output = (
-            normalise(data1, mask) * mask * normalise(data2, mask)
-        ).sum() / mask.sum()
+    output = (normalise(data1) * normalise(data2)).sum() / data1.size
     return output

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -5,7 +5,7 @@ import voltools as vt
 import gc
 from cupyx.scipy.fft import rfftn, irfftn
 from tqdm import tqdm
-from pytom_tm.correlation import mean_under_mask, std_under_mask
+from pytom_tm.correlation import normalise
 from pytom_tm.template import phase_randomize_template
 
 
@@ -365,13 +365,10 @@ class TemplateMatchingGPU:
             )
 
         # Normalize and mask template
-        mean = mean_under_mask(
+        norm = normalise(
             self.plan.template, self.plan.mask, mask_weight=self.plan.mask_weight
         )
-        std = std_under_mask(
-            self.plan.template, self.plan.mask, mean, mask_weight=self.plan.mask_weight
-        )
-        self.plan.template = ((self.plan.template - mean) / std) * self.plan.mask
+        self.plan.template = norm * self.plan.mask
 
         # Paste in center
         self.plan.template_padded[padding_index] = self.plan.template


### PR DESCRIPTION
looking through our code to see if we can up our test coverage, starting with `correlation.py`

I noticed that we have a `normalise` function that does the same thing as was implemented in `matching.py`. Updated so that `normalise` is used.
Also dropped a `mask is not None` branch from `normalised_cross_correlation` function (this function is only used in testing, specifically `test_mask.py`)

I also updated the version to account for this API change, but advise against doing a release until some actual functionality is added 