### PR TITLE
add testing for create_mask

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -34,9 +34,6 @@ def _parse_argv(argv=None):
 
 def pytom_create_mask(argv=None):
     from pytom_tm.mask import spherical_mask, ellipsoidal_mask
-
-    argv = _parse_argv(argv)
-
     # entry_point strings cannot use '\n' characters as this will break the website
     # snippet that displays the CLI help message
     # ---8<--- [start:create_mask_usage]

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -118,6 +118,16 @@ def pytom_create_mask(argv=None):
             args.radius_minor2,
             smooth=args.sigma,
         )
+    elif args.radius_minor1 is not None or args.radius_minor2 is not None:
+        # catch if only one of radius_minor1 or radius_minor2 is defined
+        gotten = (
+            "--radius_minor1" if args.radius_minor1 is not None else "--radius_minor2"
+        )
+        raise ValueError(
+            "If either '--radius-minor1' or '--radius-minor2' is given, "
+            f"both need to be given. Only got {gotten}"
+        )
+
     else:
         mask = spherical_mask(args.box_size, args.radius, smooth=args.sigma)
 

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -121,7 +121,7 @@ def pytom_create_mask(argv=None):
     elif args.radius_minor1 is not None or args.radius_minor2 is not None:
         # catch if only one of radius_minor1 or radius_minor2 is defined
         gotten = (
-            "--radius_minor1" if args.radius_minor1 is not None else "--radius_minor2"
+            "--radius-minor1" if args.radius_minor1 is not None else "--radius-minor2"
         )
         raise ValueError(
             "If either '--radius-minor1' or '--radius-minor2' is given, "

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -140,6 +140,7 @@ class TestEntryPoints(unittest.TestCase):
         # TODO: remove debug code
         print(f"cwd={pathlib.Path(os.getcwd())} prev_cwb={prev_cwd}")
         print(list(pathlib.Path(os.getcwd()).glob("*")))
+        print(f"{default_output_name=}")
         self.assertTrue(pathlib.Path(default_output_name).exists())
         # change back to previous cwd
         os.chdir(prev_cwd)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -137,6 +137,9 @@ class TestEntryPoints(unittest.TestCase):
         os.chdir(self.outputdir)
         start(defaults)
         # Make sure default file exists
+        # TODO: remove debug code
+        print(f"cwd={pathlib.Path(os.getcwd())} prev_cwb={prev_cwd}")
+        print(pathlib.Path(os.getcwd()).glob("*"))
         self.assertTrue(pathlib.Path(default_output_name).exists())
         # change back to previous cwd
         os.chdir(prev_cwd)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -152,10 +152,10 @@ class TestEntryPoints(unittest.TestCase):
         inp = defaults.copy()
         inp["--radius-minor1"] = "6"
         inp["--radius-minor2"] = "8"
-        inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
+        inp["-o"] = str(self.outputdir / "mask_ellipse.mrc")
         start(inp)
 
-        self.assertTrue(self.outputdir.joinpath("mask_elipse.mrc").exists())
+        self.assertTrue(self.outputdir.joinpath("mask_ellipse.mrc").exists())
 
     def test_match_template(self):
         defaults = {

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -127,7 +127,7 @@ class TestEntryPoints(unittest.TestCase):
             "-b": "60",
             "-r": "12",
         }
-        default_output_name = f"mask_b{defaults['-b']}px_r{defaults['-r']}px.mrc"
+        default_output_name = f"mask_b{defaults['-b']}px_r{float(defaults['-r'])}px.mrc"
 
         def start(arg_dict):
             entry_points.pytom_create_mask(prep_argv(arg_dict))

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -150,7 +150,7 @@ class TestEntryPoints(unittest.TestCase):
         inp["--radius-minor1"] = "6"
         inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
         start(inp)
-        self.assertTrue(self.outputdir.joinpath("mask_elipse").exists())
+        self.assertTrue(self.outputdir.joinpath("mask_elipse.mrc").exists())
 
     def test_match_template(self):
         defaults = {

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,5 +1,6 @@
 import unittest
 import sys
+import os
 import pathlib
 import numpy as np
 import cupy as cp
@@ -120,6 +121,32 @@ class TestEntryPoints(unittest.TestCase):
             dump.close()
             # check if the system return code is 0 (success)
             self.assertEqual(ex.exception.code, 0)
+
+    def test_create_mask(self):
+        defaults = {
+            "-b": "60",
+            "-r": "12",
+        }
+        default_output_name = f"mask_b{defaults['-b']}px_r{defaults['-r']}px.mrc"
+
+        def start(arg_dict):
+            entry_points.pytom_create_mask(prep_argv(arg_dict))
+
+        # Test defaults, do change to temp dir
+        prev_cwd = os.getcwd()
+        os.chdir(self.outputdir)
+        start(defaults)
+        # Make sure default file exists
+        self.assertTrue(pathlib.Path(default_output_name).exists())
+        # change back to previous cwd
+        os.chdir(prev_cwd)
+
+        # Smoke test eliptical masks
+        inp = defaults.copy()
+        inp["--radius-minor1"] = "6"
+        inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
+        start(inp)
+        self.assertTrue(self.outputdir.joinpath("mask_elipse").exists())
 
     def test_match_template(self):
         defaults = {

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -75,6 +75,7 @@ class TestParseArgv(unittest.TestCase):
 class TestEntryPoints(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        TEST_DATA.mkdir(parents=True)
         io.write_mrc(TEMPLATE, np.zeros((5, 5, 5), dtype=np.float32), 1)
         io.write_mrc(MASK, np.zeros((5, 5, 5), dtype=np.float32), 1)
         io.write_mrc(TOMOGRAM, np.zeros((10, 10, 10), dtype=np.float32), 1)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -137,19 +137,22 @@ class TestEntryPoints(unittest.TestCase):
         os.chdir(self.outputdir)
         start(defaults)
         # Make sure default file exists
-        # TODO: remove debug code
-        print(f"cwd={pathlib.Path(os.getcwd())} prev_cwb={prev_cwd}")
-        print(list(pathlib.Path(os.getcwd()).glob("*")))
-        print(f"{default_output_name=}")
         self.assertTrue(pathlib.Path(default_output_name).exists())
         # change back to previous cwd
         os.chdir(prev_cwd)
 
-        # Smoke test eliptical masks
+        # Check we fail loud if only one of the two options is given
+        for i in ["--radius-minor1", "--radius-minor2"]:
+            inp = defaults.copy()
+            inp[i] = "6"
+            with self.assertRaisesRegex(ValueError, f"Only got {i}"):
+                start(inp)
+
+        # smoke test eliptical mask
         inp = defaults.copy()
         inp["--radius-minor1"] = "6"
+        inp["--radius-minor2"] = "8"
         inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
-        start(inp)
         self.assertTrue(self.outputdir.joinpath("mask_elipse.mrc").exists())
 
     def test_match_template(self):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -139,7 +139,7 @@ class TestEntryPoints(unittest.TestCase):
         # Make sure default file exists
         # TODO: remove debug code
         print(f"cwd={pathlib.Path(os.getcwd())} prev_cwb={prev_cwd}")
-        print(pathlib.Path(os.getcwd()).glob("*"))
+        print(list(pathlib.Path(os.getcwd()).glob("*")))
         self.assertTrue(pathlib.Path(default_output_name).exists())
         # change back to previous cwd
         os.chdir(prev_cwd)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -60,6 +60,17 @@ def prep_argv(arg_dict):
     return argv
 
 
+class TestParseArgv(unittest.TestCase):
+    def test_parse_argv(self):
+        out = entry_points._parse_argv()
+        # This test should have been called with unittest
+        self.assertIn("unittest", out)
+        inp = ["test1", "test2"]
+        out = entry_points._parse_argv(inp)
+        for i in inp:
+            self.assertIn(i, out)
+
+
 class TestEntryPoints(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -104,7 +104,7 @@ class TestEntryPoints(unittest.TestCase):
     def setUp(self):
         # set up a destination temp dir
         tempdir = TemporaryDirectory()
-        self.outputdir = tempdir.name
+        self.outputdir = pathlib.Path(tempdir.name)
         self.addCleanup(tempdir.cleanup)
 
     def test_entry_points_exist(self):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -153,6 +153,10 @@ class TestEntryPoints(unittest.TestCase):
         inp["--radius-minor1"] = "6"
         inp["--radius-minor2"] = "8"
         inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
+        # TODO: remove DEBUG code
+        print(f'output is: {str(self.outputdir / "mask_elipse.mrc")}')
+        print(list(self.outputdir.glob("*")))
+
         self.assertTrue(self.outputdir.joinpath("mask_elipse.mrc").exists())
 
     def test_match_template(self):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 import pathlib
 import numpy as np
 import cupy as cp
@@ -63,8 +64,8 @@ def prep_argv(arg_dict):
 class TestParseArgv(unittest.TestCase):
     def test_parse_argv(self):
         out = entry_points._parse_argv()
-        # This test should have been called with unittest
-        self.assertIn("unittest", out)
+        # test behavior by repeating the behavior
+        self.assertEqual(sys.argv[1:], out)
         inp = ["test1", "test2"]
         out = entry_points._parse_argv(inp)
         for i in inp:

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -153,9 +153,7 @@ class TestEntryPoints(unittest.TestCase):
         inp["--radius-minor1"] = "6"
         inp["--radius-minor2"] = "8"
         inp["-o"] = str(self.outputdir / "mask_elipse.mrc")
-        # TODO: remove DEBUG code
-        print(f'output is: {str(self.outputdir / "mask_elipse.mrc")}')
-        print(list(self.outputdir.glob("*")))
+        start(inp)
 
         self.assertTrue(self.outputdir.joinpath("mask_elipse.mrc").exists())
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -114,4 +114,4 @@ class TestMask(unittest.TestCase):
             inp = default.copy()
             inp[i] *= -1
             with self.assertRaisesRegex(ValueError, "smooth or sd cutoff"):
-                ellipsoidal_mask(*inp)
+                ellipsoidal_mask(**inp)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,7 +1,7 @@
 import unittest
 import voltools as vt
 import cupy as cp
-from pytom_tm.mask import spherical_mask
+from pytom_tm.mask import spherical_mask, ellipsoidal_mask
 from pytom_tm.angles import angle_to_angle_list
 from pytom_tm.correlation import normalised_cross_correlation
 
@@ -93,3 +93,25 @@ class TestMask(unittest.TestCase):
         self.assertTrue(
             sum(nxcc_centered) > 99.09, msg="Precision of mask rotation is too low."
         )
+
+    def test_ellipsoidal_mask_errors(self):
+        # Make sure we error on negative box_size, major, minor1, or minor2
+        default = {
+            "box_size": 16,
+            "major": 12,
+            "minor1": 8,
+            "minor2": 6,
+            "smooth": 3,
+            "cutoff_sd": 2,
+        }
+        for i in ["box_size", "major", "minor1", "minor2"]:
+            inp = default.copy()
+            inp[i] *= -1
+            with self.assertRaisesRegex(ValueError, "box_size or radii"):
+                ellipsoidal_mask(**inp)
+        # Make sure we error on negative smooth or cutoff_sd
+        for i in ["smooth", "cutoff_sd"]:
+            inp = default.copy()
+            inp[i] *= -1
+            with self.assertRaisesRegex(ValueError, "smooth or sd cutoff"):
+                ellipsoidal_mask(*inp)


### PR DESCRIPTION
This:
- adds tests for create mask entry point
- fixes a bug where if only `--radius-minor1` or `--radius-minor2` was given instead of both, we would silently create a spherical mask instead of raising an error
- add some tests for errors that can be raised from the `ellipsoidal_mask` function (making `mask.py` reach 100% 🥳 )
- rewrote test setup so that the output directory is removed and remade between tests (and uses temp directories)
- added a tests for the `_parse_argv` 