### PR TITLE
make sure we can load a job.json from a different directory than it was run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.10.0"
+version = "0.10.1"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -577,6 +577,9 @@ class TMJob:
     def write_to_json(self, file_name: pathlib.Path) -> None:
         """Write job to .json file.
 
+        Note: This has to be run from the same cwd as where `self` was initiated
+              otherwise the path resolving doesn't make sense
+
         Parameters
         ----------
         file_name: pathlib.Path

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -600,7 +600,7 @@ class TMJob:
         ]
         for key, value in d.items():
             if isinstance(value, pathlib.Path):
-                d[key] = str(value)
+                d[key] = str(value.resolve())
         # wrangle dtype conversion
         d["output_dtype"] = str(np.dtype(d["output_dtype"]))
         with open(file_name, "w") as fstream:

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -444,14 +444,6 @@ class TestTMJob(unittest.TestCase):
         job = load_json_to_tmjob(TEST_JOB_OLD_VERSION)
         self.assertEqual(job.ctf_data[0]["phase_shift_deg"], 0.0)
 
-        # test issue #301
-        # make sure we can load if we change into the result dir
-        with chdir(TEST_DATA_DIR):
-            job = load_json_to_tmjob(TEST_JOB_JSON_BASE)
-            self.assertIsInstance(
-                job, TMJob, msg="TMJob could not be properly loaded after chdir."
-            )
-
     def test_custom_angular_search(self):
         with TemporaryDirectory() as data_dir:
             data_dir = pathlib.Path(data_dir)
@@ -857,4 +849,30 @@ class TestTMJob(unittest.TestCase):
         self.assertTrue(
             (defocus_offsets == defocus_offsets_inverted).sum() == 1,
             msg="inverted handedness should have one identical offset",
+        )
+
+    def test_running_with_relative_paths(self):
+        # test issue #301
+        # make sure we can load if we run with relative paths
+        # and chdir out of the result dir
+        with chdir(TEST_DATA_DIR):
+            job = TMJob(
+                "0",
+                10,
+                TEST_TOMOGRAM.name,
+                TEST_TEMPLATE.name,
+                TEST_MASK.name,
+                TEST_DATA_DIR,  # should end up in the expected spot
+                angle_increment=ANGULAR_SEARCH,
+                voxel_size=1.0,
+            )
+
+        job = load_json_to_tmjob(TEST_JOB_JSON)
+        self.assertIsInstance(
+            job,
+            TMJob,
+            msg=(
+                "TMJob could not be properly loaded after running "
+                "with relative paths and chdir."
+            ),
         )

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -866,8 +866,10 @@ class TestTMJob(unittest.TestCase):
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
+            job.start_job(0, return_volumes=False)
+            job.write_to_json("test_issue_301.json")
 
-        job = load_json_to_tmjob(TEST_JOB_JSON)
+        job = load_json_to_tmjob(TEST_DATA_DIR / "test_issue_301.json")
         self.assertIsInstance(
             job,
             TMJob,

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -859,9 +859,9 @@ class TestTMJob(unittest.TestCase):
             job = TMJob(
                 "0",
                 10,
-                TEST_TOMOGRAM.name,
-                TEST_TEMPLATE.name,
-                TEST_MASK.name,
+                pathlib.Path(TEST_TOMOGRAM.name),
+                pathlib.Path(TEST_TEMPLATE.name),
+                pathlib.Path(TEST_MASK.name),
                 TEST_DATA_DIR,  # should end up in the expected spot
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,


### PR DESCRIPTION
Should close #301 

This:
- [x] adds a test to see if we can load the json from the results directory, that fails on the current version of the code (mimicking issue #301, fails with the expected error on 35ffba1)
- [x] resolves the paths when writing to json
- [x] add a note that calling write_to_json from a different directory than the job was initiated breaks the paths
- [x] update version (I think this is a bugfix, not an API change)