### PR TITLE
swap input to starfiles instead of directories, and add absolute paths to output for pytom_merge_star.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.10.1"
+version = "0.11.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -11,6 +11,7 @@ from pytom_tm.io import (
     read_mrc_meta_data,
     read_mrc,
     CheckFileExists,
+    CheckListOfFilesExists,
     ParseLogging,
     CheckDirExists,
     ParseSearch,
@@ -1127,7 +1128,7 @@ def merge_stars(argv=None):
         "--input-star-files",
         type=pathlib.Path,
         required=True,
-        action=CheckFileExists,
+        action=CheckListOfFilesExists,
         nargs="+",
         help=(
             "List of star files to merge, " "script will only try to merge unique files"

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1124,14 +1124,13 @@ def merge_stars(argv=None):
     )
     parser.add_argument(
         "-i",
-        "--input-dir",
+        "--input-star-files",
         type=pathlib.Path,
-        required=False,
-        default="./",
-        action=CheckDirExists,
+        required=True,
+        action=CheckFileExists,
+        nargs="+",
         help=(
-            "Directory with star files, "
-            "script will try to merge all files that end in '.star'."
+            "List of star files to merge, " "script will only try to merge unique files"
         ),
     )
     parser.add_argument(
@@ -1165,4 +1164,4 @@ def merge_stars(argv=None):
     argv = _parse_argv(argv)
     args = parser.parse_args(argv)
     logging.basicConfig(level=args.log, force=True)
-    merge_st(args.input_dir, args.output_file, args.relion5_compat)
+    merge_st(args.input_star_files, args.output_file, args.relion5_compat)

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1162,7 +1162,13 @@ def merge_stars(argv=None):
     )
 
     # ---8<--- [end:merge_stars_usage]
-    argv = _parse_argv(argv)
+
+    # Add hidden argument to prevent logging override for logtests
+    parser.add_argument(
+        "--log-test", help=argparse.SUPPRESS, action="store_true", default=False
+    )
     args = parser.parse_args(argv)
-    logging.basicConfig(level=args.log, force=True)
+    if not args.log_test:
+        logging.basicConfig(level=args.log, force=True)
+
     merge_st(args.input_star_files, args.output_file, args.relion5_compat)

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1131,7 +1131,7 @@ def merge_stars(argv=None):
         action=CheckListOfFilesExists,
         nargs="+",
         help=(
-            "List of star files to merge, " "script will only try to merge unique files"
+            "List of star files to merge, script will only try to merge unique files"
         ),
     )
     parser.add_argument(

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -65,6 +65,24 @@ class CheckFileExists(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
+class CheckListOfFilesExists(argparse.Action):
+    """argparse.Action subclass to check if an expected input file exists."""
+
+    def __call__(
+        self,
+        parser,
+        namespace,
+        values: pathlib.Path,
+        option_string: str | None = None,
+    ):
+        for val in values:
+            if not val.is_file():
+                parser.error(
+                    f"{option_string} got a file path that does not exist: {val}"
+                )
+        setattr(namespace, self.dest, values)
+
+
 class LargerThanZero(argparse.Action):
     """argparse.Action subclass to constrain an input value to larger than zero only."""
 

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -42,7 +42,7 @@ class CheckDirExists(argparse.Action):
         option_string: str | None = None,
     ):
         if not values.is_dir():
-            parser.error(f"{option_string} got a file path that does not exist ")
+            parser.error(f"{option_string} got a directory path that does not exist ")
 
         setattr(namespace, self.dest, values)
 
@@ -57,8 +57,10 @@ class CheckFileExists(argparse.Action):
         values: pathlib.Path,
         option_string: str | None = None,
     ):
-        if not values.exists():
-            parser.error(f"{option_string} got a file path that does not exist ")
+        if not values.is_file():
+            parser.error(
+                f"{option_string} got a file path that does not exist: {values}"
+            )
 
         setattr(namespace, self.dest, values)
 

--- a/src/pytom_tm/merge_stars.py
+++ b/src/pytom_tm/merge_stars.py
@@ -5,15 +5,17 @@ import logging
 
 
 def merge_stars(
-    input_dir: pathlib.Path, output_file: pathlib.Path, relion5_compat: bool = False
+    input_star_files: list[pathlib.Path],
+    output_file: pathlib.Path,
+    relion5_compat: bool = False,
 ) -> None:
     """Merge particle starfiles together for RELION4 or make an importable RELION5
     starfile pointing to all the starfiles
 
     Parameters
     ----------
-    input_dir: pathlib.Path
-        Input directory that cointains all the particle starfiles
+    input_star_file: list[pathlib.Path]
+        List of input starfiles
     output_file: pathlib.Path
         Output file to be written
     relion5_compat: Bool, default False
@@ -21,17 +23,26 @@ def merge_stars(
         concatenating all the starfiles together (default)
     """
 
-    files = [f for f in input_dir.iterdir() if f.suffix == ".star"]
+    files = set(f.resolve() for f in input_star_files)
+
+    # Warn if we end up with less files (due to symlinks pointing to the same thing
+    # or the user giving the same star file multiple times)
+    if len(files) != len(input_star_files):
+        logging.warning("Found duplicate input, only using unique star files")
 
     if len(files) == 0:
         raise ValueError("No starfiles in directory.")
-
-    logging.info("Concatting and writing star files")
+    elif len(files) < 2 and not relion5_compat:
+        raise ValueError(
+            "Only one (unique) starfile given which doesn't make sense to merge"
+        )
 
     dataframes = (starfile.read(f) for f in files)
     if not relion5_compat:
+        logging.info("Concatting and writing star files")
         output = pd.concat(dataframes, ignore_index=True)
     else:
+        logging.info("Writing out 2-column relion5 star file")
         data = []
         for i, df in enumerate(dataframes):
             if "rlnTomoName" not in df.columns:

--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -164,7 +164,7 @@ def run_job_parallel(
                 for p in procs:
                     # if one of the processes is no longer alive and has a failed exit
                     # we should error
-                    if not p.is_alive() and p.exitcode == 1:  # to prevent a deadlock
+                    if not p.is_alive() and p.exitcode != 0:  # to prevent a deadlock
                         [
                             x.terminate() for x in procs
                         ]  # kill all spawned processes if something broke

--- a/src/pytom_tm/utils.py
+++ b/src/pytom_tm/utils.py
@@ -1,20 +1,21 @@
 import os
 import sys
+import contextlib
 
 
-class mute_stdout_stderr:
+@contextlib.contextmanager
+def mute_stdout_stderr():
     """Context manager to redirect stdout and stderr to devnull. Only used to prevent
     terminal flooding in unittests."""
 
-    def __enter__(self):
-        self.outnull = open(os.devnull, "w")
-        self.old_stdout = sys.stdout
-        self.old_stderr = sys.stderr
-        sys.stdout = self.outnull
-        sys.stderr = self.outnull
-        return self
-
-    def __exit__(self):
-        sys.stdout = self.old_stdout
-        sys.stderr = self.old_stderr
-        self.outnull.close()
+    outnull = open(os.devnull, "w")
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = outnull
+    sys.stderr = outnull
+    try:
+        yield
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        outnull.close()

--- a/src/pytom_tm/utils.py
+++ b/src/pytom_tm/utils.py
@@ -6,8 +6,10 @@ import contextlib
 @contextlib.contextmanager
 def mute_stdout_stderr():
     """Context manager to redirect stdout and stderr to devnull. Only used to prevent
-    terminal flooding in unittests."""
+    terminal flooding in unittests. If an error is raised and not caught before, this
+    will hard-exit out"""
 
+    fail = False
     outnull = open(os.devnull, "w")
     old_stdout = sys.stdout
     old_stderr = sys.stderr
@@ -15,7 +17,11 @@ def mute_stdout_stderr():
     sys.stderr = outnull
     try:
         yield
+    except Exception:  # Bare exception to exit without printing anything
+        fail = True
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr
         outnull.close()
+        if fail:
+            sys.exit(2)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -109,7 +109,7 @@ class TestMergeStars(unittest.TestCase):
 
         # test that we pass if we just give one starfile in this mode
         outfile2 = str(self.tempdir / "single_test.star")
-        merge_stars(["-i", in_files[0], "-o", outfile])
+        merge_stars(["-i", in_files[0], "-o", outfile, "--relion5-compat"])
 
         # make sure we only written a single line
         out2 = starfile.read(outfile2)
@@ -155,7 +155,7 @@ class TestMergeStars(unittest.TestCase):
         # Make a joined file via the entry point
         # mimick star expansion on a bash shell
         in_files = glob.glob(f"{self.dirname}/*.star")
-        with self.assertLogs(level="Warning") as cm:
+        with self.assertLogs(level="WARNING") as cm:
             # Give all the files twice
             merge_stars(["-i"] + in_files + in_files + ["-o", outfile])
         for o in cm.output:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -4,7 +4,9 @@ import starfile
 import glob
 from tempfile import TemporaryDirectory
 from pytom_tm.entry_points import merge_stars
+from pytom_tm.utils import mute_stdout_stderr
 from testing_utils import make_random_particles
+import sys
 
 
 class TestMergeStars(unittest.TestCase):
@@ -13,17 +15,21 @@ class TestMergeStars(unittest.TestCase):
         self.addCleanup(tempdir.cleanup)
         self.dirname = tempdir.name
         self.tempdir = pathlib.Path(tempdir.name)
+        self.n = 10
+        particles1 = make_random_particles(n=self.n)
+        particles2 = make_random_particles(n=self.n)
+        self.particles = [particles1, particles2]
 
-    def test_error_on_empty(self):
+    def test_error_function_on_empty(self):
+        from pytom_tm.merge_stars import merge_stars as ms
+
         # make sure we raise if we don't find any starfiles
         with self.assertRaisesRegex(ValueError, "No starfiles"):
-            merge_stars(["-i", f"{self.dirname}"])
+            ms([], self.tempdir / "not_relevant.star")
 
     def test_relion4_mode(self):
         # write 2 starfiles
-        particles1 = make_random_particles()
-        particles2 = make_random_particles()
-        for particle in [particles1, particles2]:
+        for particle in self.particles:
             tomo_id = particle["rlnMicrographName"][0]
             starfile.write(
                 {"particles": particle}, self.tempdir / f"{tomo_id}_particles.star"
@@ -31,13 +37,18 @@ class TestMergeStars(unittest.TestCase):
 
         outfile = str(self.tempdir / "test.star")
         # Make a joined file via the entry point
-        merge_stars(["-i", f"{self.dirname}", "-o", outfile])
+        # mimick star expansion on a bash shell
+        in_files = glob.glob(f"{self.dirname}/*.star")
+        merge_stars(["-i"] + in_files + ["-o", outfile])
 
         # make sure we can read the output starfile
         out = starfile.read(outfile)
 
+        # make sure we have the number of expected lines
+        self.assertEqual(self.n * 2, len(out))
+
         # check that both tomo IDs are in the new starfile
-        for particle in [particles1, particles2]:
+        for particle in self.particles:
             for name in set(particle["rlnMicrographName"]):
                 self.assertIn(name, set(out["rlnMicrographName"]))
 
@@ -46,9 +57,7 @@ class TestMergeStars(unittest.TestCase):
         # with a RELION5 flag
 
         # write 2 relion 4 starfiles
-        particles1 = make_random_particles()
-        particles2 = make_random_particles()
-        for particle in [particles1, particles2]:
+        for particle in self.particles:
             tomo_id = particle["rlnMicrographName"][0]
             starfile.write(
                 {"particles": particle}, self.tempdir / f"{tomo_id}_particles.star"
@@ -56,8 +65,9 @@ class TestMergeStars(unittest.TestCase):
 
         outfile = str(self.tempdir / "test.star")
         # Make sure entry point fails if trying to do relion5 merge
+        in_files = glob.glob(f"{self.dirname}/*.star")
         with self.assertRaisesRegex(ValueError, "rlnTomoName"):
-            merge_stars(["-i", f"{self.dirname}", "-o", outfile, "--relion5-compat"])
+            merge_stars(["-i"] + in_files + ["-o", outfile, "--relion5-compat"])
 
     def test_relion5_mode(self):
         particles1 = make_random_particles(relion5=True)
@@ -69,8 +79,11 @@ class TestMergeStars(unittest.TestCase):
             )
 
         outfile = str(self.tempdir / "test.star")
+        # Make sure entry point fails if trying to do relion5 merge
+        in_files = glob.glob(f"{self.dirname}/*.star")
+
         # Make a joined file via the entry point
-        merge_stars(["-i", f"{self.dirname}", "-o", outfile, "--relion5-compat"])
+        merge_stars(["-i"] + in_files + ["-o", outfile, "--relion5-compat"])
 
         # make sure we can read the output starfile
         out = starfile.read(outfile)
@@ -91,12 +104,21 @@ class TestMergeStars(unittest.TestCase):
             temp_tomoname = set(temp["rlnTomoName"])
             self.assertIn(tomoname, temp_tomoname)
 
-    def test_multi_input(self):
+    def test_fail_on_dir_input(self):
+        # temp test to check unroling
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        with self.assertRaises(SystemExit) as ex, mute_stdout_stderr():
+            merge_stars(["-i", f"{self.dirname}", "-o", "irrelevant.star"])
+        self.assertEqual(ex.exception.code, 2)
+        # temp tests to make sure we revert the muting
+        self.assertIs(sys.stdout, old_stdout)
+        self.assertIs(sys.stderr, old_stderr)
+
+    def test_multi_dir_input(self):
         # write 2 starfiles
-        n = 10
-        particles = [make_random_particles(n=n) for i in range(2)]
         directories = [self.tempdir / f"test{i}" for i in range(2)]
-        for particle, directory in zip(particles, directories):
+        for particle, directory in zip(self.particles, directories):
             directory.mkdir()
             tomo_id = particle["rlnMicrographName"][0]
             starfile.write(
@@ -114,30 +136,10 @@ class TestMergeStars(unittest.TestCase):
         out = starfile.read(outfile)
 
         # make sure we have the number of particles we expect
-        self.assertEqual(len(out), 2 * n)
+        self.assertEqual(len(out), 2 * self.n)
 
-        # Test the same if we input multiple directories
-        # remove outfile to make sure it is not testing the previous output
-        outfile.remove()
-        self.assertFalse(outfile.exists())
+    def test_non_unique_input(self):
+        self.fail()
 
-        merge_stars(["-i"] + directories + ["-o", outfile])
-
-        # make sure we can read the output starfile
-        out2 = starfile.read(outfile)
-        # make sure we have the number of particles we expect
-        self.assertEqual(len(out2), 2 * n)
-
-        # make sure we can mix and match and still don't duplicate particles
-        # TODO: make sure we want this functionality
-        # remove outfile to make sure it is not testing the previous output
-        outfile.remove()
-        self.assertFalse(outfile.exists())
-
-        merge_stars(["-i"] + star_files + directories + ["-o", outfile])
-
-        # make sure we can read the output starfile
-        out3 = starfile.read(outfile)
-
-        # make sure we have the number of particles we expect
-        self.assertEqual(len(out3), 2 * n)
+    def test_single_input(self):
+        self.fail()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -108,7 +108,7 @@ class TestMergeStars(unittest.TestCase):
         # temp test to check unroling
         old_stdout = sys.stdout
         old_stderr = sys.stderr
-        with self.assertRaises(SystemExit) as ex, mute_stdout_stderr():
+        with mute_stdout_stderr(), self.assertRaises(SystemExit) as ex:
             merge_stars(["-i", f"{self.dirname}", "-o", "irrelevant.star"])
         self.assertEqual(ex.exception.code, 2)
         # temp tests to make sure we revert the muting

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -5,7 +5,7 @@ import glob
 from tempfile import TemporaryDirectory
 from pytom_tm.entry_points import merge_stars
 from pytom_tm.utils import mute_stdout_stderr
-from testing_utils import make_random_particles
+from testing_utils import make_random_particles, chdir
 
 
 class TestMergeStars(unittest.TestCase):
@@ -106,6 +106,15 @@ class TestMergeStars(unittest.TestCase):
             temp = starfile.read(filename)
             temp_tomoname = set(temp["rlnTomoName"])
             self.assertIn(tomoname, temp_tomoname)
+
+        # Recheck that we can read all the star files even if we are in a different cwd
+        tempdir2 = TemporaryDirectory()
+        with chdir(tempdir2):
+            for _, (tomoname, filename) in out.iterrows():
+                temp = starfile.read(filename)
+                temp_tomoname = set(temp["rlnTomoName"])
+                self.assertIn(tomoname, temp_tomoname)
+        tempdir2.cleanup()
 
         # test that we pass if we just give one starfile in this mode
         outfile2 = str(self.tempdir / "single_test.star")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -118,7 +118,7 @@ class TestMergeStars(unittest.TestCase):
 
         # test that we pass if we just give one starfile in this mode
         outfile2 = str(self.tempdir / "single_test.star")
-        merge_stars(["-i", in_files[0], "-o", outfile, "--relion5-compat"])
+        merge_stars(["-i", in_files[0], "-o", outfile2, "--relion5-compat"])
 
         # make sure we only written a single line
         out2 = starfile.read(outfile2)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -6,7 +6,6 @@ from tempfile import TemporaryDirectory
 from pytom_tm.entry_points import merge_stars
 from pytom_tm.utils import mute_stdout_stderr
 from testing_utils import make_random_particles
-import sys
 
 
 class TestMergeStars(unittest.TestCase):
@@ -51,6 +50,10 @@ class TestMergeStars(unittest.TestCase):
         for particle in self.particles:
             for name in set(particle["rlnMicrographName"]):
                 self.assertIn(name, set(out["rlnMicrographName"]))
+
+        # test that we fail if we just give one starfile in this mode
+        with self.assertRaisesRegex(ValueError, "doesn't make sense to merge"):
+            merge_stars(["-i", in_files[0], "-o", outfile])
 
     def test_fail_on_incompatible_starfiles(self):
         # Make sure we fail if we try to combine RELION4 starfiles
@@ -104,16 +107,18 @@ class TestMergeStars(unittest.TestCase):
             temp_tomoname = set(temp["rlnTomoName"])
             self.assertIn(tomoname, temp_tomoname)
 
+        # test that we pass if we just give one starfile in this mode
+        outfile2 = str(self.tempdir / "single_test.star")
+        merge_stars(["-i", in_files[0], "-o", outfile])
+
+        # make sure we only written a single line
+        out2 = starfile.read(outfile2)
+        self.assertEqual(1, len(out2))
+
     def test_fail_on_dir_input(self):
-        # temp test to check unroling
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
         with mute_stdout_stderr(), self.assertRaises(SystemExit) as ex:
             merge_stars(["-i", f"{self.dirname}", "-o", "irrelevant.star"])
         self.assertEqual(ex.exception.code, 2)
-        # temp tests to make sure we revert the muting
-        self.assertIs(sys.stdout, old_stdout)
-        self.assertIs(sys.stderr, old_stderr)
 
     def test_multi_dir_input(self):
         # write 2 starfiles
@@ -139,7 +144,28 @@ class TestMergeStars(unittest.TestCase):
         self.assertEqual(len(out), 2 * self.n)
 
     def test_non_unique_input(self):
-        self.fail()
+        # write 2 starfiles
+        for particle in self.particles:
+            tomo_id = particle["rlnMicrographName"][0]
+            starfile.write(
+                {"particles": particle}, self.tempdir / f"{tomo_id}_particles.star"
+            )
 
-    def test_single_input(self):
-        self.fail()
+        outfile = str(self.tempdir / "test.star")
+        # Make a joined file via the entry point
+        # mimick star expansion on a bash shell
+        in_files = glob.glob(f"{self.dirname}/*.star")
+        with self.assertLogs(level="Warning") as cm:
+            # Give all the files twice
+            merge_stars(["-i"] + in_files + in_files + ["-o", outfile])
+        for o in cm.output:
+            if "duplicate input" in o:
+                break
+            else:
+                self.fail("expected warning is not logged")  # pragma: no cover
+
+        # make sure we can read the output starfile
+        out = starfile.read(outfile)
+
+        # make sure we only have the number of expected lines from the unique files
+        self.assertEqual(self.n * 2, len(out))

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -166,7 +166,7 @@ class TestMergeStars(unittest.TestCase):
         in_files = glob.glob(f"{self.dirname}/*.star")
         with self.assertLogs(level="WARNING") as cm:
             # Give all the files twice
-            merge_stars(["-i"] + in_files + in_files + ["-o", outfile])
+            merge_stars(["-i"] + in_files + in_files + ["-o", outfile, "--log-test"])
         for o in cm.output:
             if "duplicate input" in o:
                 break

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -109,7 +109,7 @@ class TestMergeStars(unittest.TestCase):
 
         # Recheck that we can read all the star files even if we are in a different cwd
         tempdir2 = TemporaryDirectory()
-        with chdir(tempdir2):
+        with chdir(tempdir2.name):
             for _, (tomoname, filename) in out.iterrows():
                 temp = starfile.read(filename)
                 temp_tomoname = set(temp["rlnTomoName"])


### PR DESCRIPTION
Should close #302 
This:
- [x] adds (failing) tests for the multi star file input behavior
- [x] adds test that we raise on directories input
- [x] adds test that we warn if we get the same star file twice, but don't process it twice
- [x] adds (failing) tests for the absolute output with relion5 behavior
- [x] swap to multi star file input behavior instead of directory input
- [x] makes output with relion5-compat absolute paths
- [x] update version to 0.11.0 for the changed functionality
- [x] added a secret `--log-test` variable that prevents log override from the `--log` option

Some other fixes that came in due to looking at the functions again:
- [x] switch mute_sdtout_stderr from utils.py to a contextlib.contextmanager and resolve bug in exit method
- [x] fix a possible parallel deadlock if a process failed with a different exit code than 1