### PR TITLE
fix deprecation warnings

### DIFF
--- a/src/pytom_tm/merge_stars.py
+++ b/src/pytom_tm/merge_stars.py
@@ -43,7 +43,7 @@ def merge_stars(
             return out
         # Assuming dict here
         if not relion5_compat:
-            logging.warn(
+            logging.warning(
                 f"{f} seems to be a multi-data-block starfile, will only "
                 "concatenate the 'particles' data block "
             )


### PR DESCRIPTION
Was looking through the latest log and saw the following deprecation warnings:
```
./__w/pytom-match-pick/pytom-match-pick/src/pytom_tm/merge_stars.py:46: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
  logging.warn(
/__w/pytom-match-pick/pytom-match-pick/src/pytom_tm/merge_stars.py:46: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
  logging.warn(
```

This solves those