### PR TITLE
force tilt angles for TMJob

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.11.1"
+version = "0.12.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1078,11 +1078,11 @@ def match_template(argv=None):
         args.template,
         args.mask,
         args.destination,
+        tilt_angles=tilt_angles,
         angle_increment=args.angular_search,
         mask_is_spherical=True
         if args.non_spherical_mask is None
         else (not args.non_spherical_mask),
-        tilt_angles=tilt_angles,
         tilt_weighting=per_tilt_weighting,
         search_x=args.search_x,
         search_y=args.search_y,

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -961,9 +961,10 @@ class TMJob:
             )
 
         # apply the optional band pass and whitening filter to the search region
-        search_volume = np.real(
-            irfftn(rfftn(search_volume) * tomo_filter, s=search_volume.shape)
-        )
+        # TODO: undo the debug comments
+        # search_volume = np.real(
+        #    irfftn(rfftn(search_volume) * tomo_filter, s=search_volume.shape)
+        # )
 
         # load rotation search
         angle_ids = list(range(self.start_slice, self.n_rotations, self.steps_slice))

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -855,15 +855,12 @@ class TMJob:
             angle map), when no volumes are returned the output consists of a dictionary
             with search statistics
         """
-        # next fast fft len
-        logging.debug(
-            "Next fast fft shape: "
-            f"{tuple([next_fast_len(s, real=True) for s in self.search_size])}"
-        )
-        search_volume = np.zeros(
-            tuple([next_fast_len(s, real=True) for s in self.search_size]),
+        tomo = read_mrc(self.tomogram)
+        fast_tomo = np.zeros(
+            tuple([next_fast_len(s, real=True) for s in tomo.shape]),
             dtype=np.float32,
         )
+        fast_tomo[: tomo.shape[0], : tomo.shape[1], tomo.shape[2]] = tomo
 
         # load template and mask
         template, mask = (read_mrc(self.template), read_mrc(self.mask))
@@ -873,7 +870,7 @@ class TMJob:
         # first generate bandpass filters
         if not (self.low_pass is None and self.high_pass is None):
             tomo_filter *= create_gaussian_band_pass(
-                search_volume.shape, self.voxel_size, self.low_pass, self.high_pass
+                fast_tomo.shape, self.voxel_size, self.low_pass, self.high_pass
             ).astype(np.float32)
             template_wedge *= create_gaussian_band_pass(
                 self.template_shape, self.voxel_size, self.low_pass, self.high_pass
@@ -882,7 +879,7 @@ class TMJob:
         # then multiply with optional whitening filters
         if self.whiten_spectrum:
             tomo_filter *= profile_to_weighting(
-                np.load(self.whitening_filter), search_volume.shape
+                np.load(self.whitening_filter), fast_tomo.shape
             ).astype(np.float32)
             template_wedge *= profile_to_weighting(
                 np.load(self.whitening_filter), self.template_shape
@@ -917,7 +914,7 @@ class TMJob:
         # for the tomogram a binary wedge is generated to explicitly set the missing
         # wedge region to 0
         tomo_filter *= create_wedge(
-            search_volume.shape,
+            fast_tomo.shape,
             self.tilt_angles,
             self.voxel_size,
             cut_off_radius=1.0,
@@ -948,15 +945,24 @@ class TMJob:
                 irfftn(rfftn(template) * template_wedge, s=template.shape),
                 self.voxel_size,
             )
-        # actually load the volume, apply optional filters, slice it down
-        # to subvolume
-        # TODO: we might want to rewrite to only do this once in a volume split
-        tomo = read_mrc(self.tomogram)
-        tomo = np.real(irfftn(rfftn(tomo) * tomo_filter, s=search_volume.shape))
+        # next fast fft len
+        logging.debug(
+            "Next fast fft shape: "
+            f"{tuple([next_fast_len(s, real=True) for s in self.search_size])}"
+        )
+        search_volume = np.zeros(
+            tuple([next_fast_len(s, real=True) for s in self.search_size]),
+            dtype=np.float32,
+        )
+
+        # apply optional filters to tomogram and slice it down to subvolume
+        # TODO: we might want to rewrite this to only do this and the tomo loading
+        # once in a volume split
+        fast_tomo = np.real(irfftn(rfftn(fast_tomo) * tomo_filter, s=fast_tomo.shape))
         search_volume[
             : self.search_size[0], : self.search_size[1], : self.search_size[2]
         ] = np.ascontiguousarray(
-            tomo[
+            fast_tomo[
                 self.search_origin[0] : self.search_origin[0] + self.search_size[0],
                 self.search_origin[1] : self.search_origin[1] + self.search_size[1],
                 self.search_origin[2] : self.search_origin[2] + self.search_size[2],

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -860,7 +860,7 @@ class TMJob:
             tuple([next_fast_len(s, real=True) for s in tomo.shape]),
             dtype=np.float32,
         )
-        fast_tomo[: tomo.shape[0], : tomo.shape[1], tomo.shape[2]] = tomo
+        fast_tomo[: tomo.shape[0], : tomo.shape[1], : tomo.shape[2]] = tomo
 
         # load template and mask
         template, mask = (read_mrc(self.template), read_mrc(self.mask))

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -61,9 +61,9 @@ def load_json_to_tmjob(
         pathlib.Path(data["template"]),
         pathlib.Path(data["mask"]),
         pathlib.Path(data["output_dir"]),
+        tilt_angles=data["tilt_angles"],
         angle_increment=data.get("angle_increment", data["rotation_file"]),
         mask_is_spherical=data["mask_is_spherical"],
-        tilt_angles=data["tilt_angles"],
         tilt_weighting=data["tilt_weighting"],
         search_x=data["search_x"],
         search_y=data["search_y"],
@@ -264,9 +264,9 @@ class TMJob:
         template: pathlib.Path,
         mask: pathlib.Path,
         output_dir: pathlib.Path,
+        tilt_angles: list[float, ...],
         angle_increment: str | float | None = None,
         mask_is_spherical: bool = True,
-        tilt_angles: list[float, ...] | None = None,
         tilt_weighting: bool = False,
         search_x: list[int, int] | None = None,
         search_y: list[int, int] | None = None,
@@ -303,13 +303,13 @@ class TMJob:
             path to mask MRC
         output_dir: pathlib.Path
             path to output directory
+        tilt_angles: list[float, ...],
+            tilt angles of tilt-series used to reconstruct tomogram, if only two floats
+            will be used to generate a continuous wedge model
         angle_increment: Union[str, float]; default 7.00
             angular increment of template search
         mask_is_spherical: bool, default True
             whether template mask is spherical, reduces computation complexity
-        tilt_angles: Optional[list[float, ...]], default None
-            tilt angles of tilt-series used to reconstruct tomogram, if only two floats
-            will be used to generate a continuous wedge model
         tilt_weighting: bool, default False
             use advanced tilt weighting options, can be supplemented with CTF parameters
             and accumulated dose
@@ -900,68 +900,65 @@ class TMJob:
             ).astype(np.float32)
 
         # if tilt angles are provided we can create wedge filters
-        if self.tilt_angles is not None:
-            if self.tilt_weighting and self.defocus_handedness != 0:
-                # adjust ctf parameters for this specific patch in the tomogram
-                full_tomo_center = np.array(self.tomo_shape) / 2
-                patch_center = (
-                    np.array(self.search_origin) + np.array(self.search_size) / 2
-                )
-                relative_patch_center_angstrom = (
-                    patch_center - full_tomo_center
-                ) * self.voxel_size
-                defocus_offsets = get_defocus_offsets(
-                    relative_patch_center_angstrom[0],  # x-coordinate
-                    relative_patch_center_angstrom[2],  # z-coordinate
-                    self.tilt_angles,
-                    angles_in_degrees=True,
-                    invert_handedness=self.defocus_handedness < 0,
-                )
-                for ctf, defocus_shift in zip(self.ctf_data, defocus_offsets):
-                    ctf.defocus = ctf.defocus + defocus_shift * 1e-10
-                logging.debug(
-                    "Patch center (nr. of voxels): "
-                    f"{np.array_str(relative_patch_center_angstrom, precision=2)}"
-                )
-                logging.debug(
-                    "Defocus values (um): "
-                    f"{[round(ctf.defocus * 1e6, 2) for ctf in self.ctf_data]}",
-                )
-
-            # for the tomogram a binary wedge is generated to explicitly set the missing
-            # wedge region to 0
-            tomo_filter *= create_wedge(
-                search_volume.shape,
+        if self.tilt_weighting and self.defocus_handedness != 0:
+            # adjust ctf parameters for this specific patch in the tomogram
+            full_tomo_center = np.array(self.tomo_shape) / 2
+            patch_center = np.array(self.search_origin) + np.array(self.search_size) / 2
+            relative_patch_center_angstrom = (
+                patch_center - full_tomo_center
+            ) * self.voxel_size
+            defocus_offsets = get_defocus_offsets(
+                relative_patch_center_angstrom[0],  # x-coordinate
+                relative_patch_center_angstrom[2],  # z-coordinate
                 self.tilt_angles,
-                self.voxel_size,
-                cut_off_radius=1.0,
                 angles_in_degrees=True,
-                tilt_weighting=False,
-            ).astype(np.float32)
-            # for the template a binary or per-tilt-weighted wedge is generated
-            # depending on the options
-            template_wedge *= create_wedge(
-                self.template_shape,
-                self.tilt_angles,
-                self.voxel_size,
-                cut_off_radius=1.0,
-                angles_in_degrees=True,
-                tilt_weighting=self.tilt_weighting,
-                accumulated_dose_per_tilt=self.dose_accumulation,
-                ctf_params_per_tilt=self.ctf_data,
-            ).astype(np.float32)
+                invert_handedness=self.defocus_handedness < 0,
+            )
+            for ctf, defocus_shift in zip(self.ctf_data, defocus_offsets):
+                ctf.defocus = ctf.defocus + defocus_shift * 1e-10
+            logging.debug(
+                "Patch center (nr. of voxels): "
+                f"{np.array_str(relative_patch_center_angstrom, precision=2)}"
+            )
+            logging.debug(
+                "Defocus values (um): "
+                f"{[round(ctf.defocus * 1e6, 2) for ctf in self.ctf_data]}",
+            )
 
-            if logging.DEBUG >= logging.root.level:
-                write_mrc(
-                    self.output_dir.joinpath("template_psf.mrc"),
-                    template_wedge,
-                    self.voxel_size,
-                )
-                write_mrc(
-                    self.output_dir.joinpath("template_convolved.mrc"),
-                    irfftn(rfftn(template) * template_wedge, s=template.shape),
-                    self.voxel_size,
-                )
+        # for the tomogram a binary wedge is generated to explicitly set the missing
+        # wedge region to 0
+        tomo_filter *= create_wedge(
+            search_volume.shape,
+            self.tilt_angles,
+            self.voxel_size,
+            cut_off_radius=1.0,
+            angles_in_degrees=True,
+            tilt_weighting=False,
+        ).astype(np.float32)
+        # for the template a binary or per-tilt-weighted wedge is generated
+        # depending on the options
+        template_wedge *= create_wedge(
+            self.template_shape,
+            self.tilt_angles,
+            self.voxel_size,
+            cut_off_radius=1.0,
+            angles_in_degrees=True,
+            tilt_weighting=self.tilt_weighting,
+            accumulated_dose_per_tilt=self.dose_accumulation,
+            ctf_params_per_tilt=self.ctf_data,
+        ).astype(np.float32)
+
+        if logging.DEBUG >= logging.root.level:
+            write_mrc(
+                self.output_dir.joinpath("template_psf.mrc"),
+                template_wedge,
+                self.voxel_size,
+            )
+            write_mrc(
+                self.output_dir.joinpath("template_convolved.mrc"),
+                irfftn(rfftn(template) * template_wedge, s=template.shape),
+                self.voxel_size,
+            )
 
         # apply the optional band pass and whitening filter to the search region
         search_volume = np.real(

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -386,21 +386,35 @@ def _create_symmetric_wedge(
     wedge: npt.NDArray[float]
         wedge volume that is a reduced fourier space object in z, i.e. shape[2] // 2 + 1
     """
-    x = (
-        np.abs(
-            np.arange(-shape[0] // 2 + shape[0] % 2, shape[0] // 2 + shape[0] % 2, 1.0)
-        )
-        / (shape[0] // 2)
-    )[:, np.newaxis]
-    z = np.arange(0, shape[2] // 2 + 1, 1.0) / (shape[2] // 2)
+    if wedge_angle < 0:
+        raise ValueError("Negative wedge angles are not defined")
+    elif wedge_angle > np.pi:
+        raise ValueError("Wedge angles bigger than 90 degrees are not defined")
 
-    # calculate the wedge mask with smooth edges
-    wedge_2d = x - np.tan(wedge_angle) * z
-    limit = (wedge_2d.max() - wedge_2d.min()) / (2 * min(shape[0], shape[2]) // 2)
-    wedge_2d[wedge_2d > limit] = limit
-    wedge_2d[wedge_2d < -limit] = -limit
-    wedge_2d = (wedge_2d - wedge_2d.min()) / (wedge_2d.max() - wedge_2d.min())
-    wedge_2d[shape[0] // 2 + 1, 0] = 1  # ensure that the zero frequency point equals 1
+    # special treatment for the 0.0 angles
+    if wedge_angle == 0.0:
+        new_shape = (shape[0], shape[2] // 2 + 1)
+        wedge_2d = np.ones(shape=new_shape)
+    else:
+        x = (
+            np.abs(
+                np.arange(
+                    -shape[0] // 2 + shape[0] % 2, shape[0] // 2 + shape[0] % 2, 1.0
+                )
+            )
+            / (shape[0] // 2)
+        )[:, np.newaxis]
+        z = np.arange(0, shape[2] // 2 + 1, 1.0) / (shape[2] // 2)
+
+        # calculate the wedge mask with smooth edges
+        wedge_2d = x - np.tan(wedge_angle) * z
+        limit = (wedge_2d.max() - wedge_2d.min()) / (2 * min(shape[0], shape[2]) // 2)
+        wedge_2d[wedge_2d > limit] = limit
+        wedge_2d[wedge_2d < -limit] = -limit
+        wedge_2d = (wedge_2d - wedge_2d.min()) / (wedge_2d.max() - wedge_2d.min())
+        wedge_2d[shape[0] // 2 + 1, 0] = (
+            1  # ensure that the zero frequency point equals 1
+        )
 
     # duplicate in x
     wedge = np.tile(wedge_2d[:, np.newaxis, :], (1, shape[1], 1))

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -78,7 +78,7 @@ class TestTMJob(unittest.TestCase):
         try:
             TEST_DATA_DIR.rmdir()
         except OSError as e:
-            print(TEST_DATA_DIR.iterdir())
+            print(f"{list(TEST_DATA_DIR.iterdir())=}")
             raise e
 
     def setUp(self):

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -84,6 +84,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=38.53,
             voxel_size=1.0,
         )

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -12,6 +12,7 @@ import time
 import numpy as np
 import voltools as vt
 import multiprocessing
+import pathlib
 from tempfile import TemporaryDirectory
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import angle_to_angle_list
@@ -25,7 +26,8 @@ TEMPLATE_SIZE = 13
 LOCATION = (77, 26, 40)
 ANGLE_ID = 100
 ANGULAR_SEARCH = 38.53
-TEST_DATA_DIR = TemporaryDirectory()
+TEMP_DIR = TemporaryDirectory()
+TEST_DATA_DIR = pathlib.Path(TEMP_DIR.name)
 TEST_TOMOGRAM = TEST_DATA_DIR.joinpath("tomogram.mrc")
 TEST_TEMPLATE = TEST_DATA_DIR.joinpath("template.mrc")
 TEST_MASK = TEST_DATA_DIR.joinpath("mask.mrc")
@@ -71,7 +73,7 @@ class TestTMJob(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        TEST_DATA_DIR.cleanup()
+        TEMP_DIR.cleanup()
 
     def setUp(self):
         self.job = TMJob(

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -74,7 +74,12 @@ class TestTMJob(unittest.TestCase):
         TEST_MASK.unlink()
         TEST_TEMPLATE.unlink()
         TEST_TOMOGRAM.unlink()
-        TEST_DATA_DIR.rmdir()
+        # TODO: remove debug code
+        try:
+            TEST_DATA_DIR.rmdir()
+        except OSError as e:
+            print(TEST_DATA_DIR.iterdir())
+            raise e
 
     def setUp(self):
         self.job = TMJob(

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -78,8 +78,7 @@ class TestTMJob(unittest.TestCase):
         try:
             TEST_DATA_DIR.rmdir()
         except OSError as e:
-            print(f"{list(TEST_DATA_DIR.iterdir())=}")
-            raise e
+            raise OSError(f"{list(TEST_DATA_DIR.iterdir())=}") from e
 
     def setUp(self):
         self.job = TMJob(

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -8,11 +8,11 @@ closed which will allow the remaining test to use the GPU.
 """
 
 import unittest
-import pathlib
 import time
 import numpy as np
 import voltools as vt
 import multiprocessing
+from tempfile import TemporaryDirectory
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import angle_to_angle_list
 from pytom_tm.parallel import run_job_parallel
@@ -25,7 +25,7 @@ TEMPLATE_SIZE = 13
 LOCATION = (77, 26, 40)
 ANGLE_ID = 100
 ANGULAR_SEARCH = 38.53
-TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath("test_data")
+TEST_DATA_DIR = TemporaryDirectory()
 TEST_TOMOGRAM = TEST_DATA_DIR.joinpath("tomogram.mrc")
 TEST_TEMPLATE = TEST_DATA_DIR.joinpath("template.mrc")
 TEST_MASK = TEST_DATA_DIR.joinpath("mask.mrc")
@@ -71,14 +71,7 @@ class TestTMJob(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        TEST_MASK.unlink()
-        TEST_TEMPLATE.unlink()
-        TEST_TOMOGRAM.unlink()
-        # TODO: remove debug code
-        try:
-            TEST_DATA_DIR.rmdir()
-        except OSError as e:
-            raise OSError(f"{list(TEST_DATA_DIR.iterdir())=}") from e
+        TEST_DATA_DIR.cleanup()
 
     def setUp(self):
         self.job = TMJob(

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -123,6 +123,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=ANGULAR_SEARCH,
             voxel_size=1.0,
         )
@@ -140,6 +141,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=ANGULAR_SEARCH,
             voxel_size=1.0,
         )
@@ -156,6 +158,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=90.00,
             voxel_size=1.0,
             whiten_spectrum=True,
@@ -184,6 +187,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=ANGULAR_SEARCH,
             voxel_size=1.0,
         )
@@ -201,6 +205,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE_WRONG_VOXEL_SIZE,
                 TEST_MASK,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
             )
 
         with self.assertRaises(
@@ -213,6 +218,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE_UNEQUAL_SPACING,
                 TEST_MASK,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
             )
 
         with self.assertRaises(
@@ -226,6 +232,7 @@ class TestTMJob(unittest.TestCase):
                 # Use unequal spaced template as broken mask
                 TEST_TEMPLATE_UNEQUAL_SPACING,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
             )
 
         # test searches raise correct errors
@@ -240,6 +247,7 @@ class TestTMJob(unittest.TestCase):
                     TEST_TEMPLATE,
                     TEST_MASK,
                     TEST_DATA_DIR,
+                    tilt_angles=[-90, 90],
                     voxel_size=1.0,
                     **{param: [-10, 100]},
                 )
@@ -253,6 +261,7 @@ class TestTMJob(unittest.TestCase):
                     TEST_TEMPLATE,
                     TEST_MASK,
                     TEST_DATA_DIR,
+                    tilt_angles=[-90, 90],
                     voxel_size=1.0,
                     **{param: [110, 130]},
                 )
@@ -266,6 +275,7 @@ class TestTMJob(unittest.TestCase):
                     TEST_TEMPLATE,
                     TEST_MASK,
                     TEST_DATA_DIR,
+                    tilt_angles=[-90, 90],
                     voxel_size=1.0,
                     **{param: [0, 120]},
                 )
@@ -278,6 +288,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE,
                 TEST_MASK,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
                 angle_increment="1.2.3",
                 voxel_size=1.0,
             )
@@ -291,6 +302,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE,
                 TEST_MASK,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
                 tomogram_mask=TEST_BROKEN_TOMOGRAM_MASK,
@@ -304,6 +316,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE,
                 TEST_MASK,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
                 tomogram_mask=TEST_WRONG_SIZE_TOMO_MASK,
@@ -322,6 +335,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE,
                 TEST_MASK_WRONG_SIZE,
                 TEST_DATA_DIR,
+                tilt_angles=[-90, 90],
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
@@ -346,13 +360,13 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=TILT_ANGLES,
             angle_increment=90.00,
             voxel_size=1.0,
             low_pass=10,
             high_pass=100,
             dose_accumulation=ACCUMULATED_DOSE,
             ctf_data=CTF_PARAMS,
-            tilt_angles=TILT_ANGLES,
             whiten_spectrum=True,
             tilt_weighting=True,
             defocus_handedness=1,
@@ -371,11 +385,11 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=TILT_ANGLES,
             angle_increment=90.00,
             voxel_size=1.0,
             dose_accumulation=ACCUMULATED_DOSE,
             ctf_data=CTF_PARAMS,
-            tilt_angles=TILT_ANGLES,
             tilt_weighting=True,
         )
         score, angle = job.start_job(0, return_volumes=True)
@@ -391,6 +405,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=90.00,
             voxel_size=1.0,
             low_pass=10,
@@ -410,6 +425,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=90.00,
             voxel_size=1.0,
             whiten_spectrum=True,
@@ -428,6 +444,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=90.00,
             voxel_size=1.0,
             whiten_spectrum=True,
@@ -503,6 +520,7 @@ class TestTMJob(unittest.TestCase):
                 TEST_TEMPLATE,
                 TEST_MASK,
                 data_dir,
+                tilt_angles=[-90, 90],
                 angle_increment=TEST_CUSTOM_ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
@@ -620,6 +638,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=ANGULAR_SEARCH,
             voxel_size=1.0,
             search_x=[9, 90],
@@ -693,6 +712,7 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=[-90, 90],
             angle_increment=ANGULAR_SEARCH,
             voxel_size=1.0,
             output_dtype=np.float16,
@@ -912,6 +932,7 @@ class TestTMJob(unittest.TestCase):
                 pathlib.Path(TEST_TEMPLATE.name),
                 pathlib.Path(TEST_MASK.name),
                 TEST_DATA_DIR,  # should end up in the expected spot
+                tilt_angles=[-90, 90],
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
@@ -952,9 +973,9 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE,
             TEST_MASK,
             TEST_DATA_DIR,
+            tilt_angles=tilt_angles,
             angle_increment=ANGULAR_SEARCH,
             voxel_size=voxel_size,
-            tilt_angles=tilt_angles,
             tilt_weighting=per_tilt_weighting,
             dose_accumulation=dose_accumulation,
             ctf_data=ctf_params,

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -2,6 +2,7 @@ import numpy as np
 import unittest
 from pytom_tm.weights import (
     create_wedge,
+    _create_symmetric_wedge,
     create_ctf,
     create_gaussian_band_pass,
     radial_reduced_grid,
@@ -122,6 +123,10 @@ class TestWeights(unittest.TestCase):
             msg="Low-pass and high-pass filter should be different",
         )
 
+    def test_create_symmetric_wedge(self):
+        with self.assertRaisesRegex(ValueError, "bigger than 90 degrees"):
+            _create_symmetric_wedge(self.volume_shape_even, 4, 1.0)
+
     def test_create_wedge(self):
         with self.assertRaises(
             ValueError,
@@ -147,6 +152,8 @@ class TestWeights(unittest.TestCase):
             "equal to 0",
         ):
             create_wedge(self.volume_shape_even, TILT_ANGLES, 1.0, cut_off_radius=0.0)
+        with self.assertRaisesRegex(ValueError, "Negative wedge angles"):
+            create_wedge(self.volume_shape_even, [-91, 91], 1.0)
 
         # create test wedges
         structured_wedge = create_wedge(


### PR DESCRIPTION
This:

- [x] Forces a TMJob to get tilt angles
- [x] remove some unnecessary checks
- [x] make symmetric wedge behave with 90 degree tilts (0 degree wedge, used for testing)
- [x] Fix a bug in the behavior of volume splits
- [x] updates the version to represent the API break
- [x] make symmetric wedge error out for broken cases (negative angles or more than 90 degree angles)
- [x] make sure all touched code is tested

(Was a big rewrite that needed to be done as part of #311, so decided to split it out to a separate PR)

