### PR TITLE
use proposed fix for BetweenZeroAndOne argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.12.0"
+version = "0.12.1"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -107,7 +107,7 @@ class BetweenZeroAndOne(argparse.Action):
     def __call__(
         self, parser, namespace, values: float, option_string: str | None = None
     ):
-        if 1.0 <= values <= 0.0:
+        if not (0.0 <= values <= 1.0):
             parser.error(
                 f"{option_string} is a fraction and can only range between 0 and 1"
             )

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -242,7 +242,7 @@ class TestEntryPoints(unittest.TestCase):
             arguments["--defocus"] = z
             start(arguments)
 
-        # test faulty args
+        # test faulty defocus args
         for z in ["asdf.txt", "asdf"]:
             dump = StringIO()
             with (
@@ -252,6 +252,21 @@ class TestEntryPoints(unittest.TestCase):
             ):
                 arguments = defaults.copy()
                 arguments["--defocus"] = z
+                start(arguments)
+            dump.close()
+            # check if the system return code is 0 (success)
+            self.assertEqual(ex.exception.code, 2)
+
+        # test faulty amplitude contrast args (not between 0-1)
+        for z in ["-0.5", "2"]:
+            dump = StringIO()
+            with (
+                self.assertRaises(SystemExit) as ex,
+                redirect_stdout(dump),
+                redirect_stderr(dump),
+            ):
+                arguments = defaults.copy()
+                arguments["--amplitude-contrast"] = z
                 start(arguments)
             dump.close()
             # check if the system return code is 0 (success)


### PR DESCRIPTION
This closes #323:

- [x] implement logic fix for the BetweenZeroAndOn argparse action as proposed in #323 
- [x] adds a test for the logic
- [x] updated version number for this bug fix