### PR TITLE
Fix tutorial tests: deal with new dataverse download naming

### DIFF
--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -42,7 +42,7 @@ jobs:
           gunzip emd_2938.map.gz
           cd ../dataset
           curl -L -O -J -H "X-Dataverse-key:${{ secrets.DATAVERSE_API_TOKEN }}" https://dataverse.nl/api/access/datafiles/384727,384717,384726,384720
-          unzip dataverse_files.zip
+          unzip doi-10.34894-tlgjcm.zip
           # this inflates into a 'tutorial' folder, moving everything out
           mv tutorial/* .
       - name: Set TQDM_MININTERVAL


### PR DESCRIPTION
Our tutorial tests are failing in unzipping the `dataverse_files.zip` file as dataverse decided to rename the default data:

>  When there are no errors, this has the effect of saving the file under the name suggested by Dataverse (which as of v6.7 will be based on the persistent identifier of the dataset and the latest version number, for example doi-10.70122-fk2-n2xgbj_1.1.zip; in prior versions the file name was dataverse_files.zip in all cases).

([ref link](https://guides.dataverse.org/en/6.7.1/api/dataaccess.html))

This updates the unzip command to the new filename