### PR TITLE
generate filters once for split jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.12.1"
+version = "0.12.2"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -549,6 +549,22 @@ class TMJob:
         # output dtype
         self.output_dtype = output_dtype
 
+        # caching stuff
+        self._tomogram_filter = None
+        self._template_filter = None
+
+    @property
+    def tomogram_filter(self) -> npt.NDArray[float]:
+        if self._tomogram_filter is None:
+            self.generate_filters()
+        return self._tomogram_filter
+
+    @property
+    def template_filter(self) -> npt.NDArray[float]:
+        if self._template_filter is None:
+            self.generate_filters()
+        return self._tomogram_filter
+
     def copy(self) -> TMJob:
         """Create a copy of the TMJob
 
@@ -594,8 +610,12 @@ class TMJob:
         with open(file_name, "w") as fstream:
             json.dump(d, fstream, indent=4, cls=CustomJSONEncoder)
 
-    def generate_masks(self) -> tuple[npt.NDArray[float], npt.NDArray[float]]:
-        """Generate the tomogram and template mask"""
+    def _generate_filters(self):
+        """Generate the tomogram and template filters and sets them to
+        self._tomogram_filter and self._template_filter.
+
+        Note that the wedge filters are missing as it is specific per volume split part
+        """
         # grab shapes and update tomogram shape to next fast fft-shape
         fast_tomo_shape = tuple(next_fast_len(s, real=True) for s in self.tomo_shape)
         template_shape = self.template_shape
@@ -622,72 +642,8 @@ class TMJob:
             template_filter *= profile_to_weighting(
                 np.load(self.whitening_filter), template_shape
             ).astype(np.float32)
-
-        # TODO deal with this part of the code in some sane matter
-        # during volume splitting
-
-        # create wedge filters if we have the info
-        # TODO: continue coding here
-        """
-        if (
-            self.ts_metadata.per_tilt_weighting
-            and self.ts_metadata.defocus_handedness != 0
-        ):
-            # adjust ctf parameters for this specific patch in the tomogram
-            full_tomo_center = np.array(fast_tomo_shape) / 2
-            patch_center = np.array(self.search_origin) + np.array(self.search_size) / 2
-            relative_patch_center_angstrom = (
-                patch_center - full_tomo_center
-            ) * self.voxel_size
-            defocus_offsets = get_defocus_offsets(
-                relative_patch_center_angstrom[0],  # x-coordinate
-                relative_patch_center_angstrom[2],  # z-coordinate
-                self.ts_metadata,
-            )
-            # TODO: make sure this doesn't lead to weird race conditions
-            for ctf, defocus_shift in zip(self.ts_metadata.ctf_data, defocus_offsets):
-                ctf.defocus = ctf.defocus + defocus_shift * 1e-10
-            logging.debug(
-                "Patch center (nr. of voxels): "
-                f"{np.array_str(relative_patch_center_angstrom, precision=2)}"
-            )
-            logging.debug(
-                "Defocus values (um): "
-                f"{[round(ctf.defocus * 1e6, 2) for ctf in self.ts_metadata.ctf_data]}",
-            )
-
-
-        # for the tomogram a binary wedge is generated to explicitly set the missing
-        # wedge region to 0
-        tomo_filter *= create_wedge(
-            fast_tomo.shape,
-            self.ts_metadata,
-            self.voxel_size,
-            cut_off_radius=1.0,
-            per_tilt_weighting=False,
-        ).astype(np.float32)
-        # for the template a binary or per-tilt-weighted wedge is generated
-        # depending on the options
-        template_wedge *= create_wedge(
-            self.template_shape,
-            self.ts_metadata,
-            self.voxel_size,
-            cut_off_radius=1.0,
-        ).astype(np.float32)
-
-        if logging.DEBUG >= logging.root.level:
-            write_mrc(
-                self.output_dir.joinpath("template_psf.mrc"),
-                template_wedge,
-                self.voxel_size,
-            )
-            write_mrc(
-                self.output_dir.joinpath("template_convolved.mrc"),
-                irfftn(rfftn(template) * template_wedge, s=template.shape),
-                self.voxel_size,
-            )
-        """
-        return tomo_filter, template_filter
+        self._tomogram_filter = tomo_filter
+        self._template_filter = template_filter
 
     def split_rotation_search(self, n: int) -> list[TMJob, ...]:
         """Split the search into sub_jobs by dividing the rotations. Sub jobs will
@@ -798,6 +754,9 @@ class TMJob:
                 if np.all(tomogram_mask[*slices] <= 0):
                     # No non-masked unique data-points, skipping
                     continue
+
+            # pregenerate the comon part of the filters
+            self._generate_filters()
             new_job = self.copy()
             new_job.leader = self.job_key
             new_job.job_key = self.job_key + str(i)
@@ -937,26 +896,6 @@ class TMJob:
         # load template and mask
         template, mask = (read_mrc(self.template), read_mrc(self.mask))
 
-        # init tomogram and template weighting
-        tomo_filter, template_wedge = 1, 1
-        # first generate bandpass filters
-        if not (self.low_pass is None and self.high_pass is None):
-            tomo_filter *= create_gaussian_band_pass(
-                fast_tomo.shape, self.voxel_size, self.low_pass, self.high_pass
-            ).astype(np.float32)
-            template_wedge *= create_gaussian_band_pass(
-                self.template_shape, self.voxel_size, self.low_pass, self.high_pass
-            ).astype(np.float32)
-
-        # then multiply with optional whitening filters
-        if self.whiten_spectrum:
-            tomo_filter *= profile_to_weighting(
-                np.load(self.whitening_filter), fast_tomo.shape
-            ).astype(np.float32)
-            template_wedge *= profile_to_weighting(
-                np.load(self.whitening_filter), self.template_shape
-            ).astype(np.float32)
-
         # create wedge filters
         if (
             self.ts_metadata.per_tilt_weighting
@@ -985,6 +924,13 @@ class TMJob:
                 f"{[round(ctf.defocus * 1e6, 2) for ctf in self.ts_metadata.ctf_data]}",
             )
 
+        # grab common tomogram and template filter
+        # (or generated them if this job isn't volume split)
+        tomo_filter = self.tomogram_filter
+        template_filter = self.template_filter
+        # The wedge filters use the patch specific defocus, so can't be pregenerated
+        # when splitting the volume
+
         # for the tomogram a binary wedge is generated to explicitly set the missing
         # wedge region to 0
         tomo_filter *= create_wedge(
@@ -996,7 +942,7 @@ class TMJob:
         ).astype(np.float32)
         # for the template a binary or per-tilt-weighted wedge is generated
         # depending on the options
-        template_wedge *= create_wedge(
+        template_filter *= create_wedge(
             self.template_shape,
             self.ts_metadata,
             self.voxel_size,
@@ -1006,12 +952,12 @@ class TMJob:
         if logging.DEBUG >= logging.root.level:
             write_mrc(
                 self.output_dir.joinpath("template_psf.mrc"),
-                template_wedge,
+                template_filter,
                 self.voxel_size,
             )
             write_mrc(
                 self.output_dir.joinpath("template_convolved.mrc"),
-                irfftn(rfftn(template) * template_wedge, s=template.shape),
+                irfftn(rfftn(template) * template_filter, s=template.shape),
                 self.voxel_size,
             )
 
@@ -1068,7 +1014,7 @@ class TMJob:
             angle_list=angle_list,
             angle_ids=angle_ids,
             mask_is_spherical=self.mask_is_spherical,
-            wedge=template_wedge,
+            wedge=template_filter,
             stats_roi=search_volume_roi,
             noise_correction=self.random_phase_correction,
             rng_seed=self.rng_seed,

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -594,6 +594,11 @@ class TMJob:
         with open(file_name, "w") as fstream:
             json.dump(d, fstream, indent=4, cls=CustomJSONEncoder)
 
+    def generate_masks(self) -> tuple[npt.NDArray[float], npt.NDArray[float]]:
+        """Generate the tomogram and template mask"""
+        tomo_filter, template_filter = 1, 1
+        return tomo_filter, template_filter
+
     def split_rotation_search(self, n: int) -> list[TMJob, ...]:
         """Split the search into sub_jobs by dividing the rotations. Sub jobs will
         obtain the key self.job_key + str(i) when looping over range(n).

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -556,13 +556,13 @@ class TMJob:
     @property
     def tomogram_filter(self) -> npt.NDArray[float]:
         if self._tomogram_filter is None:
-            self.generate_filters()
+            self._generate_filters()
         return self._tomogram_filter
 
     @property
     def template_filter(self) -> npt.NDArray[float]:
         if self._template_filter is None:
-            self.generate_filters()
+            self._generate_filters()
         return self._tomogram_filter
 
     def copy(self) -> TMJob:

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -563,7 +563,7 @@ class TMJob:
     def template_filter(self) -> npt.NDArray[float]:
         if self._template_filter is None:
             self._generate_filters()
-        return self._tomogram_filter
+        return self._template_filter
 
     def copy(self) -> TMJob:
         """Create a copy of the TMJob

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -596,7 +596,97 @@ class TMJob:
 
     def generate_masks(self) -> tuple[npt.NDArray[float], npt.NDArray[float]]:
         """Generate the tomogram and template mask"""
+        # grab shapes and update tomogram shape to next fast fft-shape
+        fast_tomo_shape = tuple(next_fast_len(s, real=True) for s in self.tomo_shape)
+        template_shape = self.template_shape
+        # mask_shape = self.mask_shape
+        voxel_size = self.voxel_size
+
+        # initial filters
         tomo_filter, template_filter = 1, 1
+
+        # bandpass filters
+        if not (self.low_pass is None and self.high_pass is None):
+            tomo_filter *= create_gaussian_band_pass(
+                fast_tomo_shape, voxel_size, self.low_pass, self.high_pass
+            ).astype(np.float32)
+            template_filter *= create_gaussian_band_pass(
+                template_shape, voxel_size, self.low_pass, self.high_pass
+            ).astype(np.float32)
+
+        # multiply with optional whitening filters
+        if self.whiten_spectrum:
+            tomo_filter *= profile_to_weighting(
+                np.load(self.whitening_filter), fast_tomo_shape
+            ).astype(np.float32)
+            template_filter *= profile_to_weighting(
+                np.load(self.whitening_filter), template_shape
+            ).astype(np.float32)
+
+        # TODO deal with this part of the code in some sane matter
+        # during volume splitting
+
+        # create wedge filters if we have the info
+        # TODO: continue coding here
+        """
+        if (
+            self.ts_metadata.per_tilt_weighting
+            and self.ts_metadata.defocus_handedness != 0
+        ):
+            # adjust ctf parameters for this specific patch in the tomogram
+            full_tomo_center = np.array(fast_tomo_shape) / 2
+            patch_center = np.array(self.search_origin) + np.array(self.search_size) / 2
+            relative_patch_center_angstrom = (
+                patch_center - full_tomo_center
+            ) * self.voxel_size
+            defocus_offsets = get_defocus_offsets(
+                relative_patch_center_angstrom[0],  # x-coordinate
+                relative_patch_center_angstrom[2],  # z-coordinate
+                self.ts_metadata,
+            )
+            # TODO: make sure this doesn't lead to weird race conditions
+            for ctf, defocus_shift in zip(self.ts_metadata.ctf_data, defocus_offsets):
+                ctf.defocus = ctf.defocus + defocus_shift * 1e-10
+            logging.debug(
+                "Patch center (nr. of voxels): "
+                f"{np.array_str(relative_patch_center_angstrom, precision=2)}"
+            )
+            logging.debug(
+                "Defocus values (um): "
+                f"{[round(ctf.defocus * 1e6, 2) for ctf in self.ts_metadata.ctf_data]}",
+            )
+
+
+        # for the tomogram a binary wedge is generated to explicitly set the missing
+        # wedge region to 0
+        tomo_filter *= create_wedge(
+            fast_tomo.shape,
+            self.ts_metadata,
+            self.voxel_size,
+            cut_off_radius=1.0,
+            per_tilt_weighting=False,
+        ).astype(np.float32)
+        # for the template a binary or per-tilt-weighted wedge is generated
+        # depending on the options
+        template_wedge *= create_wedge(
+            self.template_shape,
+            self.ts_metadata,
+            self.voxel_size,
+            cut_off_radius=1.0,
+        ).astype(np.float32)
+
+        if logging.DEBUG >= logging.root.level:
+            write_mrc(
+                self.output_dir.joinpath("template_psf.mrc"),
+                template_wedge,
+                self.voxel_size,
+            )
+            write_mrc(
+                self.output_dir.joinpath("template_convolved.mrc"),
+                irfftn(rfftn(template) * template_wedge, s=template.shape),
+                self.voxel_size,
+            )
+        """
         return tomo_filter, template_filter
 
     def split_rotation_search(self, n: int) -> list[TMJob, ...]:

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -671,6 +671,9 @@ class TMJob:
                 "Could not further split this job as it already has subjobs assigned!"
             )
 
+        # pregenerate the common part of the filters
+        self._generate_filters()
+
         sub_jobs = []
         for i in range(n):
             new_job = self.copy()
@@ -719,6 +722,8 @@ class TMJob:
             raise TMJobError(
                 "Could not further split this job as it already has subjobs assigned!"
             )
+        # pregenerate the common part of the filters
+        self._generate_filters()
 
         search_size = self.search_size
         if self.tomogram_mask is not None:
@@ -761,8 +766,6 @@ class TMJob:
                     # No non-masked unique data-points, skipping
                     continue
 
-            # pregenerate the comon part of the filters
-            self._generate_filters()
             new_job = self.copy()
             new_job.leader = self.job_key
             new_job.job_key = self.job_key + str(i)

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -590,6 +590,11 @@ class TMJob:
         d.pop("sub_jobs")
         d.pop("search_origin")
         d.pop("search_size")
+
+        # pop cached numpy arrays that we don't want to dump
+        for c in ["_tomogram_filter", "_template_filter"]:
+            d.pop(c)
+
         d["search_x"] = [
             self.search_origin[0],
             self.search_origin[0] + self.search_size[0],
@@ -607,6 +612,7 @@ class TMJob:
                 d[key] = str(value.absolute())
         # wrangle dtype conversion
         d["output_dtype"] = str(np.dtype(d["output_dtype"]))
+
         with open(file_name, "w") as fstream:
             json.dump(d, fstream, indent=4, cls=CustomJSONEncoder)
 

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -339,6 +339,13 @@ class TestTMJob(unittest.TestCase):
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
+        # Test double splitting the same job on rotation
+        job = self.job.copy()
+        self.assertEqual(len(job.sub_jobs), 0)
+        _ = job.split_rotation_search(2)
+        self.assertNotEqual(len(job.sub_jobs), 0)
+        with self.assertRaisesRegex(TMJobError, "already has subjobs"):
+            job.split_rotation_search(2)
 
     def test_tm_job_copy(self):
         copy = self.job.copy()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -34,6 +34,7 @@ TS_METADATA = TiltSeriesMetaData(tilt_angles=[-90, 90])
 TEMP_DIR = TemporaryDirectory()
 TEST_DATA_DIR = pathlib.Path(TEMP_DIR.name)
 TEST_TOMOGRAM = TEST_DATA_DIR.joinpath("tomogram.mrc")
+TEST_TOMOGRAM_UNEQUAL_SPACING = TEST_DATA_DIR.joinpath("tomogram_unequal_spacing.mrc")
 TEST_SYMLINK_TOMOGRAM = TEST_DATA_DIR.joinpath("margomot.mrc")
 TEST_BROKEN_TOMOGRAM_MASK = TEST_DATA_DIR.joinpath("broken_tomogram_mask.mrc")
 TEST_WRONG_SIZE_TOMO_MASK = TEST_DATA_DIR.joinpath("wrong_size_tomogram_mask.mrc")
@@ -115,6 +116,8 @@ class TestTMJob(unittest.TestCase):
             TEST_TEMPLATE_UNEQUAL_SPACING, template, voxel_size=(1.5, 1.0, 2.0)
         )
         write_mrc(TEST_TOMOGRAM, volume, 1.0)
+        write_mrc(TEST_TOMOGRAM_UNEQUAL_SPACING, volume, voxel_size=(1.5, 1.0, 2.0))
+
         # do a run without splitting to compare against
         job = TMJob(
             "0",
@@ -207,9 +210,25 @@ class TestTMJob(unittest.TestCase):
                 TEST_DATA_DIR,
                 ts_metadata=TS_METADATA,
             )
+        with self.assertRaisesRegex(
+            UnequalSpacingError,
+            "tomogram voxel spacing",
+            msg="Unequal spacing should raise specific Error",
+        ):
+            TMJob(
+                "0",
+                10,
+                TEST_TOMOGRAM_UNEQUAL_SPACING,
+                TEST_TEMPLATE,
+                TEST_MASK,
+                TEST_DATA_DIR,
+                ts_metadata=TS_METADATA,
+            )
 
-        with self.assertRaises(
-            UnequalSpacingError, msg="Unequal spacing should raise specific Error"
+        with self.assertRaisesRegex(
+            UnequalSpacingError,
+            "template voxel spacing",
+            msg="Unequal spacing should raise specific Error",
         ):
             TMJob(
                 "0",
@@ -221,8 +240,10 @@ class TestTMJob(unittest.TestCase):
                 ts_metadata=TS_METADATA,
             )
 
-        with self.assertRaises(
-            UnequalSpacingError, msg="Unequal spacing should raise specific Error"
+        with self.assertRaisesRegex(
+            UnequalSpacingError,
+            "mask voxel spacing",
+            msg="Unequal spacing should raise specific Error",
         ):
             TMJob(
                 "0",
@@ -339,6 +360,20 @@ class TestTMJob(unittest.TestCase):
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
+        # Test negative or zero voxel size
+        for voxel_size in [0, -1.0]:
+            with self.assertRaisesRegex(ValueError, "Invalid voxel size"):
+                TMJob(
+                    "0",
+                    10,
+                    TEST_TOMOGRAM,
+                    TEST_TEMPLATE,
+                    TEST_MASK,
+                    TEST_DATA_DIR,
+                    ts_metadata=TS_METADATA,
+                    voxel_size=voxel_size,
+                )
+
         # Test error double splitting the same job
         job_rot = self.job.copy()
         job_vol = self.job.copy()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -4,7 +4,7 @@ from dataclasses import asdict
 import numpy as np
 import voltools as vt
 import mrcfile
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import angle_to_angle_list
 from pytom_tm.tmjob import TMJob, TMJobError, load_json_to_tmjob, get_defocus_offsets
@@ -350,6 +350,34 @@ class TestTMJob(unittest.TestCase):
             copy.tomo_shape,
             msg="Tomogram shape not correct in job, perhaps transpose issue?",
         )
+
+    def test_filter_caching(self):
+        job = self.job.copy()
+        # make sure cache is empty
+        self.assertIs(job._tomogram_filter, None)
+        self.assertIs(job._template_filter, None)
+
+        # make sure asking for either tomogram- or template-filter fills the cache
+        # for both
+        self.assertIsNot(job.tomogram_filter, None)
+        self.assertIsNot(job._tomogram_filter, None)
+        self.assertIsNot(job._template_filter, None)
+
+        # reset and repeat for template filter
+        job._tomogram_filter = None
+        job._template_filter = None
+        self.assertIsNot(job.template_filter, None)
+        self.assertIsNot(job._tomogram_filter, None)
+        self.assertIsNot(job._template_filter, None)
+
+        # make sure they are copied over (for splitting)
+        job2 = job.copy()
+        self.assertIsNot(job2._tomogram_filter, None)
+        self.assertIsNot(job2._template_filter, None)
+
+        # make sure we can still json dump
+        with NamedTemporaryFile(suffix=".json") as temp:
+            job.write_to_json(pathlib.Path(temp.name))
 
     def test_tm_job_weighting_options(self):
         # run with all options

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -339,13 +339,23 @@ class TestTMJob(unittest.TestCase):
                 angle_increment=ANGULAR_SEARCH,
                 voxel_size=1.0,
             )
-        # Test double splitting the same job on rotation
-        job = self.job.copy()
-        self.assertEqual(len(job.sub_jobs), 0)
-        _ = job.split_rotation_search(2)
-        self.assertNotEqual(len(job.sub_jobs), 0)
-        with self.assertRaisesRegex(TMJobError, "already has subjobs"):
-            job.split_rotation_search(2)
+        # Test error double splitting the same job
+        job_rot = self.job.copy()
+        job_vol = self.job.copy()
+        self.assertEqual(len(job_rot.sub_jobs), 0)
+        self.assertEqual(len(job_vol.sub_jobs), 0)
+        # do initial splits
+        _ = job_rot.split_rotation_search(2)
+        _ = job_vol.split_volume_search((2, 2, 2))
+        self.assertNotEqual(len(job_rot.sub_jobs), 0)
+        self.assertNotEqual(len(job_vol.sub_jobs), 0)
+
+        # Now make sure that both jobs on any other split
+        for job in [job_rot, job_vol]:
+            with self.assertRaisesRegex(TMJobError, "already has subjobs"):
+                job.split_rotation_search(2)
+            with self.assertRaisesRegex(TMJobError, "already has subjobs"):
+                job.split_volume_search((2, 2, 2))
 
     def test_tm_job_copy(self):
         copy = self.job.copy()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -195,6 +195,20 @@ class TestTMJob(unittest.TestCase):
             voxel_size=1.0,
         )
 
+    def test_tm_job_defaults(self):
+        # test default angle increment
+        job = TMJob(
+            "0",
+            10,
+            TEST_TOMOGRAM,
+            TEST_TEMPLATE,
+            TEST_MASK,
+            TEST_DATA_DIR,
+            ts_metadata=TS_METADATA,
+            voxel_size=1.0,
+        )
+        self.assertEqual(job.rotation_file, 7.0)
+
     def test_tm_job_errors(self):
         with self.assertRaises(
             ValueError,


### PR DESCRIPTION
This PR:

- [x] splits out filter generation to a separate method of TMJob
- [x] makes sure it is generated only once per split
- [x] add/update tests for everything
- [x] update version number
- [x] makes test coverage 100%

Some notes:
- The ctf updating and final wedge filters have to be generated per-split-job so I left that at the current spot
- We should probably make sure that if any of the relevant attributes are read only (or invalidate the cached filters), but I feel that will require a significant rethink about the structure of the TMJob class in general

closes #317 