### PR TITLE
Ensure at least 2 pieces for GPU distribution check

### DIFF
--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -87,7 +87,7 @@ def run_job_parallel(
     n_pieces = reduce(lambda x, y: x * y, volume_splits)
 
     # error out reasonably if we can' make an even distribution
-    if n_pieces % len(gpu_ids) != 0:
+    if n_pieces > 1 and n_pieces % len(gpu_ids) != 0:
         raise ValueError(
             f"Can't evenly distribute {n_pieces} tomogram pieces over "
             f"{len(gpu_ids)} GPUs, please alter either the split or the number "


### PR DESCRIPTION
Add check for minimum pieces before volume split distribution check.

I was trying to split the rotation search of a single tomo over multiple GPU's (`-s 1 1 1` with `-g 0 1 2`). The current check doesn't allow for this apparently. 


