### PR TITLE
change warp xml reader to multiply angles with -1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.12.2"
+version = "0.13.0"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -713,7 +713,8 @@ def parse_warp_xml_data(
     def _flatten(t):
         return [float(item) for sublist in t for item in sublist if item.strip()]
 
-    flattened_tilt_angles = _flatten(tilt_angles)
+    # -1 multiplication is needed to swap between warp internal convention to pytom
+    flattened_tilt_angles = [-i for i in _flatten(tilt_angles)]
     flattened_tilt_dose = _flatten(tilt_dose)
 
     ctf_data = [

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,7 @@ import contextlib
 from tempfile import TemporaryDirectory
 import numpy as np
 import mrcfile
+from lxml import etree
 
 from pytom_tm.dataclass import CtfData, RelionTiltSeriesMetaData
 from pytom_tm.io import (
@@ -69,6 +70,20 @@ class TestWarpXMLParser(unittest.TestCase):
         voxel_size, ts_metadata = parse_warp_xml_data(WARP_XML, TEST_TOMOGRAM)
         for ctf in ts_metadata.ctf_data:
             self.assertTrue(10e-6 >= ctf.defocus >= 0.1e-6)
+
+    def test_correct_angle_sign(self):
+        voxel_size, ts_metadata = parse_warp_xml_data(WARP_XML, TEST_TOMOGRAM)
+        # grab raw xml data
+        tree = etree.parse(WARP_XML)
+        tilt_angle_nodes = tree.findall(".//Angles")
+        angles = [
+            float(j)
+            for i in tilt_angle_nodes
+            for j in i.text.split("\n")
+            if i.text.strip()
+        ]
+        for a, b in zip(ts_metadata, angles):
+            self.assertEqual(a, -b)
 
 
 class TestBrokenMRC(unittest.TestCase):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -82,7 +82,7 @@ class TestWarpXMLParser(unittest.TestCase):
             for j in i.text.split("\n")
             if i.text.strip()
         ]
-        for a, b in zip(ts_metadata, angles):
+        for a, b in zip(ts_metadata.tilt_angles, angles):
             self.assertEqual(a, -b)
 
 


### PR DESCRIPTION
From our own internal discussion, this seems like the correct thing to do. (also mentioned here: https://github.com/SBC-Utrecht/pytom-match-pick/discussions/266#discussioncomment-13735010)

This does **not** deal with the defocus handedness, as this is set by the `AreAnglesInverted` flag of the xml, which we currently not read. It only deals with the tomogram reconstruction handedness.

This would be particularly bad if the sampling wasn't symmetric with respect to angles.

[EDIT: we ended up testing this, see [this comment](https://github.com/SBC-Utrecht/pytom-match-pick/pull/334#issuecomment-3958455104) text below is to keep history intact]

We haven't truly tested this but reasoned our way in the following way:
1) we know our angles are correct for an AreTomo reconstructed tomogram with their tilt-angles
2) we know that with the same tilt-angles Warp gives us a reconstruction that is mirrored
2b) we know that flipping the defocus handedness does not change anything other than the  `AreAnglesInverted` flag. and leads to tomograms that are always mirrored compared to AreTomo
3) if we multiply the angles with -1 in the xml, we do end up with a reconstruction that has the same handedness as AreTomo
4) Hence, for our internal angles to match the tomogram from Warp, we should multiply the tilt-angles with -1

@shahpnmlab do you agree with this or have other strong opinions? For our info, did you ever test it with a non-symmetric sampling, as on symmetric sampling this would barely show up?