### PR TITLE
reimplement job splitting to allow for arbitrary number of gpus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.13.0"
+version = "0.13.1"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -4,6 +4,7 @@ import logging
 import queue
 import time
 import contextlib
+from math import lcm
 from multiprocessing.managers import BaseProxy
 from functools import reduce
 from pytom_tm.tmjob import TMJob
@@ -55,6 +56,50 @@ def gpu_runner(
                 break
 
 
+def split_job_efficiently(
+    job: TMJob, volume_splits: tuple[int, int, int], gpus: int
+) -> list[TMJob, ...]:
+    """Do volume and angle splits in such a way that we can fill any number of gpus
+    with the same number of jobs for each gpu and the least amount of tomogram loading
+
+    Parameters
+    ----------
+    job: pytom_tm.tmjob.TMJob
+      a TM job to split into subjobs
+    volume_splits: tuple[int, int, int]
+      tuple of len 3 with number of splits in x, y, and z
+    gpus: int
+      number of gpus to split for
+    """
+    n_pieces = reduce(lambda x, y: x * y, volume_splits)
+    least_total_jobs = lcm(n_pieces, gpus)
+    n_angle_splits = least_total_jobs // n_pieces
+
+    if n_angle_splits > job.n_rotations:
+        # This should not happen for any sane setup,
+        # as the number of angles is normally in the 1000s
+        raise ValueError(
+            "Can't fill the assigned nuber of GPUs!"
+            f" number of assigned gpus: {gpus}, "
+            f" maximum number of possible jobs: {n_pieces * job.n_rotations}"
+        )
+
+    # do volume splits
+    if n_pieces > 1:
+        jobs = job.split_volume_search(volume_splits)
+    else:
+        jobs = [job]
+
+    # do angle splits
+    if n_angle_splits > 1:
+        out = []
+        for j in jobs:
+            out += j.split_rotation_search(n_angle_splits)
+    else:
+        out = jobs
+    return out
+
+
 def run_job_parallel(
     main_job: TMJob,
     volume_splits: tuple[int, int, int],
@@ -83,40 +128,7 @@ def run_job_parallel(
     result: tuple[npt.NDArray[float], npt.NDArray[float]]
         the volumes with the LCCmax and angle ids
     """
-
-    n_pieces = reduce(lambda x, y: x * y, volume_splits)
-
-    # error out reasonably if we can' make an even distribution
-    if n_pieces % len(gpu_ids) != 0:
-        raise ValueError(
-            f"Can't evenly distribute {n_pieces} tomogram pieces over "
-            f"{len(gpu_ids)} GPUs, please alter either the split or the number "
-            "of GPUs"
-        )
-    jobs = []
-
-    # =================== Splitting into subjobs ===============
-    if n_pieces == 1:
-        if len(gpu_ids) > 1:  # split rotation search
-            jobs = main_job.split_rotation_search(len(gpu_ids))
-
-        else:  # we just run the whole tomo on a single gpu
-            jobs.append(main_job)
-
-    elif n_pieces > 1:
-        rotation_split_factor = len(gpu_ids) // n_pieces
-
-        if (
-            rotation_split_factor >= 2
-        ):  # we can split the rotation search for the subvolumes
-            for j in main_job.split_volume_search(volume_splits):
-                jobs += j.split_rotation_search(rotation_split_factor)
-
-        else:  # only split the subvolume search
-            jobs = main_job.split_volume_search(volume_splits)
-
-    else:
-        raise ValueError("Invalid number of pieces in split volume")
+    jobs = split_job_efficiently(main_job, volume_splits, len(gpu_ids))
 
     # ================== Execution of jobs =========================
     if len(jobs) == 1:
@@ -179,9 +191,3 @@ def run_job_parallel(
 
         # merge split jobs; pass along the list of stats to annotate them in main_job
         return main_job.merge_sub_jobs(stats=results)
-
-    else:
-        ValueError(
-            "For some reason there are more gpu_ids than split job, this should never "
-            "happen."
-        )

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -160,7 +160,7 @@ class TestTMJob(unittest.TestCase):
         # test volume split only
         job = self.job.copy()
         jobs = split_job_efficiently(job, (2, 2, 1), 4)
-        self.assertEqual(len(jobs), 6)
+        self.assertEqual(len(jobs), 4)
 
         # test no splits
         job = self.job.copy()

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -125,7 +125,7 @@ class TestTMJob(unittest.TestCase):
 
         # not divisible
         job = self.job.copy()
-        jobs = split_job_efficiently(job, (3, 3, 1), 4)
+        jobs = split_job_efficiently(job, (3, 2, 1), 4)
         # 6 jobs don't nicely divide on 4 GPUS,
         # but 12 is the smallest multiple of 6 that does
         self.assertEqual(len(jobs), 12)

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import angle_to_angle_list
 from pytom_tm.dataclass import TiltSeriesMetaData
-from pytom_tm.parallel import run_job_parallel
+from pytom_tm.parallel import run_job_parallel, split_job_efficiently
 from pytom_tm.tmjob import TMJob
 from pytom_tm.io import write_mrc
 
@@ -114,3 +114,40 @@ class TestTMJob(unittest.TestCase):
         self.assertTrue(score.max() > 0.931, msg="lcc max value lower than expected")
         self.assertEqual(ANGLE_ID, angle[ind])
         self.assertSequenceEqual(LOCATION, ind)
+
+    def test_split_job_efficiently(self):
+        # test more volume splits than gpus
+        # divisable
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (2, 2, 2), 4)
+        # jobs should be the same as total volume splits
+        self.assertEqual(len(jobs), 8)
+
+        # not divisible
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (3, 3, 1), 4)
+        # 6 jobs don't nicely divide on 4 GPUS,
+        # but 12 is the smallest multiple of 6 that does
+        self.assertEqual(len(jobs), 12)
+
+        # Test more gpus than jobs
+        # divisible
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (2, 2, 1), 8)
+        # should be the same as the numbers of gpus (8)
+        self.assertEqual(len(jobs), 8)
+
+        # not divisble
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (2, 2, 1), 6)
+        # 12 is the smallest multple of 4 that can be evenly split by 6 gpus
+        self.assertEqual(len(jobs), 12)
+
+        # test imposible error
+        job = self.job.copy()
+        job.n_rotations = 6
+        with self.assertRaisesRegex(ValueError, r"gpus: 16.*jobs: 12"):
+            _ = split_job_efficiently(job, (2, 1, 1), 16)
+        # make sure it does work with more splits
+        jobs = split_job_efficiently(job, (2, 2, 1), 16)
+        self.assertEqual(len(jobs), 16)

--- a/tests/test00_parallel.py
+++ b/tests/test00_parallel.py
@@ -151,3 +151,19 @@ class TestTMJob(unittest.TestCase):
         # make sure it does work with more splits
         jobs = split_job_efficiently(job, (2, 2, 1), 16)
         self.assertEqual(len(jobs), 16)
+
+        # test angle split only
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (1, 1, 1), 6)
+        self.assertEqual(len(jobs), 6)
+
+        # test volume split only
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (2, 2, 1), 4)
+        self.assertEqual(len(jobs), 6)
+
+        # test no splits
+        job = self.job.copy()
+        jobs = split_job_efficiently(job, (1, 1, 1), 1)
+        self.assertEqual(len(jobs), 1)
+        self.assertIs(job, jobs[0])

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -338,13 +338,6 @@ class TestEntryPoints(unittest.TestCase):
                 start(arguments)
             self.assertIn("gpu indices", dump.getvalue())
             dump.close()
-        # test error when volume splits can't be evenly distributed by gpus
-        arguments = defaults.copy()
-        # 4 pieces can't be fit on 3 gpus
-        arguments["--volume-split"] = "2 2 1"
-        arguments["-g"] = "0 0 0"
-        with self.assertRaisesRegex(ValueError, r"4 tomogram pieces.*3 GPUs"):
-            start(arguments)
 
         # test warp xml metadata reading
         arguments = defaults.copy()


### PR DESCRIPTION
supersedes #330 

Pytom can now handle almost any combination of volume splits numbers and gpu numbers.
It is done in the following priority:
1. every gpu gets the same number of tasks
2. we try to load (partial) tomograms the least amount of times

The one edge case we can't resolve is if the number of gpus is bigger than the number of volume splits times the number of sampled angles as that is the smallest quantity we have for subjobs. It errors out if that happens
 