### PR TITLE
change help formatter to ArgumentDefaultsHelpFormatter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
           path: coverage.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_number: ${{ steps.get-pr.outputs.PR }}
-          minimum_coverage: 92
+          minimum_coverage: 94
           show_missing: True
           fail_below_threshold: True
           link_missing_lines: True

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -34,7 +34,7 @@ code = ("""
 ---8<--- "entry_points.py:create_template_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'type='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)
@@ -51,7 +51,7 @@ code = ("""
 ---8<--- "entry_points.py:create_mask_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'type='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)
@@ -115,7 +115,7 @@ code = ("""
 ---8<--- "entry_points.py:match_template_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type=', 'error_on_multi_column='))
+    if not any(keyword in line for keyword in ('action=', 'type=', 'error_on_multi_column='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)
@@ -168,7 +168,7 @@ code = ("""
 ---8<--- "entry_points.py:extract_candidates_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'type='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)
@@ -185,7 +185,7 @@ code = ("""
 ---8<--- "entry_points.py:estimate_roc_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'type='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)
@@ -206,7 +206,7 @@ code = ("""
 ---8<--- "entry_points.py:merge_stars_usage"
 """)
 cleaned_lines = [line.lstrip() for line in code.splitlines()
-    if not any(keyword in line for keyword in ('action=', 'default=', 'type='))
+    if not any(keyword in line for keyword in ('action=', 'type='))
 ]
 cleaned_code = '\n'.join(cleaned_lines)
 exec(cleaned_code)

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -239,7 +239,7 @@ def pytom_create_template(argv=None):
         "--log",
         type=str,
         required=False,
-        default="info",
+        default="INFO",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -239,7 +239,7 @@ def pytom_create_template(argv=None):
         "--log",
         type=str,
         required=False,
-        default=logging.INFO,
+        default="info",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -45,6 +45,7 @@ def pytom_create_mask(argv=None):
         prog="pytom_create_mask.py",
         description="Create a mask for template matching. "
         "-- Marten Chaillet (@McHaillet)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "-b",
@@ -156,6 +157,7 @@ def pytom_create_template(argv=None):
         prog="pytom_create_template.py",
         description="Generate template from MRC density. "
         "-- Marten Chaillet (@McHaillet)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "-i",
@@ -314,6 +316,7 @@ def estimate_roc(argv=None):
         prog="pytom_estimate_roc.py",
         description="Estimate ROC curve from TMJob file. "
         "-- Marten Chaillet (@McHaillet)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "-j",
@@ -453,6 +456,7 @@ def extract_candidates(argv=None):
     parser = argparse.ArgumentParser(
         prog="pytom_extract_candidates.py",
         description="Run candidate extraction. -- Marten Chaillet (@McHaillet)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "-j",
@@ -625,6 +629,7 @@ def match_template(argv=None):
     parser = argparse.ArgumentParser(
         prog="pytom_match_template.py",
         description="Run template matching. -- Marten Chaillet (@McHaillet)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     io_group = parser.add_argument_group("Template, search volume, and output")
     io_group.add_argument(
@@ -1123,6 +1128,7 @@ def merge_stars(argv=None):
             "Merge multiple star files in the same directory. "
             "-- Marten Chaillet (@McHaillet)"
         ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "-i",

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -60,7 +60,7 @@ def pytom_create_mask(argv=None):
         "--output-file",
         type=pathlib.Path,
         required=False,
-        help="Provide path to write output, needs to end in .mrc ."
+        help="Provide path to write output, needs to end in '.mrc'. "
         "If not provided file is written to current directory in the following format: "
         "./mask_b[box_size]px_r[radius]px.mrc ",
     )
@@ -239,7 +239,7 @@ def pytom_create_template(argv=None):
         "--log",
         type=str,
         required=False,
-        default=20,
+        default=logging.INFO,
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -343,7 +343,7 @@ def estimate_roc(argv=None):
         action=LargerThanZero,
         help="Particle diameter of the template in Angstrom. It is used during "
         "extraction to remove areas around peaks to prevent double extraction. "
-        "Minimal peak-to-peak distance after extraction will be diameter/2."
+        "Minimal peak-to-peak distance after extraction will be diameter/2. "
         "If not previously specified, this option is required. If "
         "specified in pytom_match_template, this is optional and "
         "can be used to overwrite it, which might be relevant for strongly "
@@ -393,7 +393,7 @@ def estimate_roc(argv=None):
         "--log",
         type=str,
         required=False,
-        default=20,
+        default="INFO",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )
@@ -563,7 +563,7 @@ def extract_candidates(argv=None):
         "--log",
         type=str,
         required=False,
-        default=20,
+        default="INFO",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )
@@ -939,7 +939,6 @@ def match_template(argv=None):
         "--rng-seed",
         type=int,
         action=LargerThanZero,
-        default=int.from_bytes(urandom(8)),
         required=False,
         help="Specify a seed for the random number generator used for phase "
         "randomization for consistent results!",
@@ -981,7 +980,7 @@ def match_template(argv=None):
         "--log",
         type=str,
         required=False,
-        default=20,
+        default="INFO",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )
@@ -990,6 +989,10 @@ def match_template(argv=None):
 
     args = parser.parse_args(argv)
     logging.basicConfig(level=args.log, force=True)
+
+    # set rng if not set
+    if args.rng_seed is None:
+        args.rng_seed = int.from_bytes(urandom(8))
 
     # set correct tilt angles
     if args.tilt_angles_first_column is not None:
@@ -1153,7 +1156,7 @@ def merge_stars(argv=None):
         "--log",
         type=str,
         required=False,
-        default=20,
+        default="INFO",
         action=ParseLogging,
         help="Can be set to `info` or `debug`",
     )

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -79,9 +79,13 @@ class TestEntryPoints(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         TEST_DATA.mkdir(parents=True)
-        io.write_mrc(TEMPLATE, np.zeros((5, 5, 5), dtype=np.float32), 1)
-        io.write_mrc(MASK, np.zeros((5, 5, 5), dtype=np.float32), 1)
-        io.write_mrc(TOMOGRAM, np.zeros((10, 10, 10), dtype=np.float32), 1)
+        volume = np.zeros((10, 10, 10), dtype=np.float32)
+        template = np.ones((5, 5, 5), dtype=np.float32)
+        volume[2:7, 2:7, 2:7] = 1.0
+
+        io.write_mrc(TEMPLATE, template, 1)
+        io.write_mrc(MASK, np.ones((5, 5, 5), dtype=np.float32), 1)
+        io.write_mrc(TOMOGRAM, volume, 1)
         io.write_mrc(RELION5_TOMOGRAM, np.zeros((10, 10, 10), dtype=np.float32), 1)
         np.savetxt(TILT_ANGLES, np.linspace(-50, 50, 35))
         np.savetxt(
@@ -433,7 +437,11 @@ class TestEntryPoints(unittest.TestCase):
         # generate match
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
-        roc_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": "1"}
+        roc_defaults = {
+            "-j": str(self.outputdir / f"{tomo_id}_job.json"),
+            "-n": "4",
+            "--particle-diameter": "5",
+        }
 
         def start(arg_dict):
             entry_points.estimate_roc(prep_argv(arg_dict))
@@ -466,7 +474,7 @@ class TestEntryPoints(unittest.TestCase):
         extract_defaults = {
             "-j": str(self.outputdir / f"{tomo_id}_job.json"),
             "-n": "1",
-            "--particle-diameter": "50",
+            "--particle-diameter": "5",
         }
 
         def start(arg_dict):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -470,7 +470,6 @@ class TestEntryPoints(unittest.TestCase):
         # generate match
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
-        print(f"{str(self.outputdir / f'{tomo_id}_job.json')}")
         extract_defaults = {
             "-j": str(self.outputdir / f"{tomo_id}_job.json"),
             "-n": "1",

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -459,6 +459,7 @@ class TestEntryPoints(unittest.TestCase):
         # generate match
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
+        print(f'{str(self.outputdir / f"{tomo_id}_job.json")}')
         extract_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
 
         def start(arg_dict):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -466,7 +466,7 @@ class TestEntryPoints(unittest.TestCase):
         extract_defaults = {
             "-j": str(self.outputdir / f"{tomo_id}_job.json"),
             "-n": "1",
-            "--particle-diameter": "1",
+            "--particle-diameter": "50",
         }
 
         def start(arg_dict):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -409,3 +409,61 @@ class TestEntryPoints(unittest.TestCase):
         arguments.pop("--tilt-angles")
         arguments["--tilt-angles-first-column"] = str(TILT_ANGLES_MULTI_COLUMN)
         start(arguments)
+
+    def test_estimate_roc(self):
+        match_defaults = {
+            "-t": str(TEMPLATE),
+            "-m": str(MASK),
+            "-v": str(TOMOGRAM),
+            "-d": str(self.outputdir),
+            "--angular-search": "35",
+            "--tilt-angles": str(TILT_ANGLES),
+            "--per-tilt-weighting": "",
+            "--dose-accumulation": str(DOSE),
+            "--defocus": str(DEFOCUS_IMOD),
+            "--amplitude-contrast": "0.08",
+            "--spherical-aberration": "2.7",
+            "--voltage": "300",
+            "--tomogram-ctf-model": "phase-flip",
+            "-g": "0",
+        }
+        # generate match
+        entry_points.match_template(prep_argv(match_defaults))
+        tomo_id = f"{TOMOGRAM.stem}"
+        roc_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
+
+        def start(arg_dict):
+            entry_points.estimate_roc(arg_dict)
+
+        # make sure we can run estimate roc
+        start(roc_defaults)
+        self.assertTrue((self.outputdir / f"{tomo_id}_roc.svg").exists())
+
+    def test_extract_candidates(self):
+        match_defaults = {
+            "-t": str(TEMPLATE),
+            "-m": str(MASK),
+            "-v": str(TOMOGRAM),
+            "-d": str(self.outputdir),
+            "--angular-search": "35",
+            "--tilt-angles": str(TILT_ANGLES),
+            "--per-tilt-weighting": "",
+            "--dose-accumulation": str(DOSE),
+            "--defocus": str(DEFOCUS_IMOD),
+            "--amplitude-contrast": "0.08",
+            "--spherical-aberration": "2.7",
+            "--voltage": "300",
+            "--tomogram-ctf-model": "phase-flip",
+            "-g": "0",
+        }
+        # generate match
+        entry_points.match_template(prep_argv(match_defaults))
+        tomo_id = f"{TOMOGRAM.stem}"
+        extract_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
+
+        def start(arg_dict):
+            entry_points.extract_candidates(arg_dict)
+
+        # make sure we can run extraction
+        start(extract_defaults)
+        self.assertTrue((self.outputdir / f"{tomo_id}_particles.star").exists())

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -433,7 +433,7 @@ class TestEntryPoints(unittest.TestCase):
         roc_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
 
         def start(arg_dict):
-            entry_points.estimate_roc(arg_dict)
+            entry_points.estimate_roc(prep_argv(arg_dict))
 
         # make sure we can run estimate roc
         start(roc_defaults)
@@ -463,7 +463,7 @@ class TestEntryPoints(unittest.TestCase):
         extract_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
 
         def start(arg_dict):
-            entry_points.extract_candidates(arg_dict)
+            entry_points.extract_candidates(prep_argv(arg_dict))
 
         # make sure we can run extraction
         start(extract_defaults)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -459,7 +459,7 @@ class TestEntryPoints(unittest.TestCase):
         # generate match
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
-        print(f'{str(self.outputdir / f"{tomo_id}_job.json")}')
+        print(f"{str(self.outputdir / f'{tomo_id}_job.json')}")
         extract_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
 
         def start(arg_dict):

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -430,7 +430,7 @@ class TestEntryPoints(unittest.TestCase):
         # generate match
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
-        roc_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
+        roc_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": "1"}
 
         def start(arg_dict):
             entry_points.estimate_roc(prep_argv(arg_dict))
@@ -460,7 +460,10 @@ class TestEntryPoints(unittest.TestCase):
         entry_points.match_template(prep_argv(match_defaults))
         tomo_id = f"{TOMOGRAM.stem}"
         print(f"{str(self.outputdir / f'{tomo_id}_job.json')}")
-        extract_defaults = {"-j": str(self.outputdir / f"{tomo_id}_job.json"), "-n": 1}
+        extract_defaults = {
+            "-j": str(self.outputdir / f"{tomo_id}_job.json"),
+            "-n": "1",
+        }
 
         def start(arg_dict):
             entry_points.extract_candidates(prep_argv(arg_dict))

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -21,9 +21,11 @@ ENTRY_POINTS_TO_TEST = [
     ("pytom_merge_stars.py", "merge_stars"),
 ]
 # Test if optional dependencies are installed
+SKIP_PLOT = False
 try:
     from pytom_tm import plotting  # noqa: F401
 except RuntimeError:
+    SKIP_PLOT = True
     pass
 else:
     ENTRY_POINTS_TO_TEST.append(("pytom_estimate_roc.py", "estimate_roc"))
@@ -410,6 +412,7 @@ class TestEntryPoints(unittest.TestCase):
         arguments["--tilt-angles-first-column"] = str(TILT_ANGLES_MULTI_COLUMN)
         start(arguments)
 
+    @unittest.skipIf(SKIP_PLOT, "plotting modules not installed")
     def test_estimate_roc(self):
         match_defaults = {
             "-t": str(TEMPLATE),
@@ -463,6 +466,7 @@ class TestEntryPoints(unittest.TestCase):
         extract_defaults = {
             "-j": str(self.outputdir / f"{tomo_id}_job.json"),
             "-n": "1",
+            "--particle-diameter": "1",
         }
 
         def start(arg_dict):


### PR DESCRIPTION
should close #321 

- [x] change help printer to include defaults
- [x] change doc building to not skip over defaults anymore 
- [x] test out new help messages
- [x] change logging defaults to the string "INFO" instead of 20 (allowed as logging level input) 
- [x] change random seed generation to outside of defaults to prevent people from thinking the one in the help message is constant and not regenerated every time you run the code 
- [x] added smoke tests for the entry points of `estimate_roc` and `extract_candidates` to make sure log defaults are sane (resulting in 100% coverage of entry_points.py)

updated usage page: 
[index.html](https://github.com/user-attachments/files/25687772/index.html) (click "skip to content" to see the new help messages, you can also locally build the whole site if you do want the icons etc to work)
