### PR TITLE
use safer init values for initial volumes

### DIFF
--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -1,4 +1,5 @@
 from packaging import version
+import math
 import pandas as pd
 import numpy as np
 import numpy.typing as npt
@@ -215,6 +216,17 @@ def extract_particles(
         symmetry=job.rotational_symmetry,
     )
 
+    # Check for invalid values or NaNs
+    for x in ["variance", "std"]:
+        if math.isinf(job.job_stats[x]) or math.isnan(job.job_stats[x]):
+            raise ValueError(
+                f"job stat '{x}' is NaN or inf, please check your volumes and update "
+                "the job_stats json accordingly"
+            )
+
+    sigma = job.job_stats["std"]
+    search_space = job.job_stats["search_space"]
+
     if tophat_filter:  # constrain the extraction with a tophat filter
         predicted_peaks = predict_tophat_mask(
             score_volume,
@@ -285,8 +297,6 @@ def extract_particles(
     score_volume[:, -particle_radius_px:, :] = 0
     score_volume[:, :, -particle_radius_px:] = 0
 
-    sigma = job.job_stats["std"]
-    search_space = job.job_stats["search_space"]
     if cut_off is None:
         # formula Rickgauer et al. (2017, eLife):
         # N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -327,11 +327,11 @@ def extract_particles(
     scores = []
 
     for _ in tqdm(range(n_particles)):
-        ind = np.unravel_index(score_volume.argmax(), score_volume.shape)
+        ind = np.unravel_index(np.nanargmax(score_volume), score_volume.shape)
 
         lcc_max = score_volume[ind]
 
-        if lcc_max <= cut_off:
+        if lcc_max <= cut_off or np.isnan(lcc_max):
             break
 
         scores.append(lcc_max)

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -79,7 +79,7 @@ def predict_tophat_mask(
     # to exclude them from the histogram
     if np.any(np.isneginf(score_volume)):
         finite_indices = np.where(np.isfinite(score_volume))
-        score_volume = np.nan_to_num(neginf=0.0)
+        score_volume = np.nan_to_num(score_volume, neginf=0.0)
     else:
         finite_indices = None, None, None
 

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -75,13 +75,21 @@ def predict_tophat_mask(
     if score_volume.dtype == np.float16:
         score_volume = score_volume.astype(np.float32)
 
+    # convert -inf (masked) scores to background 0 and kep track of them
+    # to exclude them from the histogram
+    if np.any(np.isneginf(score_volume)):
+        finite_indices = np.where(np.isfinite(score_volume))
+        score_volume = np.nan_to_num(neginf=0.0)
+    else:
+        finite_indices = None, None, None
+
     tophat = ndimage.white_tophat(
         score_volume,
         structure=ndimage.generate_binary_structure(
             rank=3, connectivity=tophat_connectivity
         ),
     )
-    y, bins = np.histogram(tophat.flatten(), bins=bins)
+    y, bins = np.histogram(tophat[finite_indices].flatten(), bins=bins)
     bin_centers = (bins[:-1] + bins[1:]) / 2
     x_raw, y_raw = (
         bin_centers[2:],

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -76,8 +76,8 @@ class TemplateMatchingPlan:
 
         # Initialize result volumes
         self.ccc_map = cp.zeros(volume_shape, dtype=cp.float32)
-        self.scores = cp.ones(volume_shape, dtype=cp.float32) * -1000
-        self.angles = cp.ones(volume_shape, dtype=cp.float32) * -1000
+        self.scores = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
+        self.angles = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
 
         self.random_phase_template_texture = None
         self.noise_scores = None
@@ -87,7 +87,7 @@ class TemplateMatchingPlan:
                 interpolation="filt_bspline",
                 device=f"gpu:{device_id}",
             )
-            self.noise_scores = cp.ones(volume_shape, dtype=cp.float32) * -1000
+            self.noise_scores = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
 
         # wait for stream to complete the work
         cp.cuda.stream.get_current_stream().synchronize()

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -76,8 +76,8 @@ class TemplateMatchingPlan:
 
         # Initialize result volumes
         self.ccc_map = cp.zeros(volume_shape, dtype=cp.float32)
-        self.scores = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
-        self.angles = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
+        self.scores = cp.ones(volume_shape, dtype=cp.float32) * float("-inf")
+        self.angles = cp.ones(volume_shape, dtype=cp.float32) * float("-inf")
 
         self.random_phase_template_texture = None
         self.noise_scores = None
@@ -87,7 +87,7 @@ class TemplateMatchingPlan:
                 interpolation="filt_bspline",
                 device=f"gpu:{device_id}",
             )
-            self.noise_scores = cp.ones(volume_shape, dtype=cp.float32) * float("nan")
+            self.noise_scores = cp.ones(volume_shape, dtype=cp.float32) * float("-inf")
 
         # wait for stream to complete the work
         cp.cuda.stream.get_current_stream().synchronize()

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -836,8 +836,8 @@ class TMJob:
 
         if not is_subvolume_split:
             scores, angles = (
-                np.zeros_like(score_volumes[0]),
-                np.zeros_like(angle_volumes[0]) - float("inf"),
+                np.zeros_like(score_volumes[0]) + float("-inf"),
+                np.zeros_like(angle_volumes[0]) + float("inf"),
             )
             for s, a in zip(score_volumes, angle_volumes):
                 angles = np.where(s > scores, a, angles)
@@ -847,7 +847,7 @@ class TMJob:
         else:
             scores, angles = (
                 np.zeros(self.search_size, dtype=np.float32),
-                np.zeros(self.search_size, dtype=np.float32) - float("inf"),
+                np.zeros(self.search_size, dtype=np.float32) + float("inf"),
             )
             for job, s, a in zip(self.sub_jobs, score_volumes, angle_volumes):
                 sub_scores = s[

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -836,8 +836,8 @@ class TMJob:
 
         if not is_subvolume_split:
             scores, angles = (
-                np.zeros_like(score_volumes[0]) - 1.0,
-                np.zeros_like(angle_volumes[0]) - 1.0,
+                np.zeros_like(score_volumes[0]),
+                np.zeros_like(angle_volumes[0]) - float("inf"),
             )
             for s, a in zip(score_volumes, angle_volumes):
                 angles = np.where(s > scores, a, angles)
@@ -847,7 +847,7 @@ class TMJob:
         else:
             scores, angles = (
                 np.zeros(self.search_size, dtype=np.float32),
-                np.zeros(self.search_size, dtype=np.float32),
+                np.zeros(self.search_size, dtype=np.float32) - float("inf"),
             )
             for job, s, a in zip(self.sub_jobs, score_volumes, angle_volumes):
                 sub_scores = s[

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -846,7 +846,7 @@ class TMJob:
                 scores = np.where(s > scores, s, scores)
         else:
             scores, angles = (
-                np.zeros(self.search_size, dtype=np.float32),
+                np.zeros(self.search_size, dtype=np.float32) + float("-inf"),
                 np.zeros(self.search_size, dtype=np.float32) + float("inf"),
             )
             for job, s, a in zip(self.sub_jobs, score_volumes, angle_volumes):

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -837,7 +837,7 @@ class TMJob:
         if not is_subvolume_split:
             scores, angles = (
                 np.zeros_like(score_volumes[0]) + float("-inf"),
-                np.zeros_like(angle_volumes[0]) + float("inf"),
+                np.zeros_like(angle_volumes[0]) + float("-inf"),
             )
             for s, a in zip(score_volumes, angle_volumes):
                 angles = np.where(s > scores, a, angles)
@@ -847,7 +847,7 @@ class TMJob:
         else:
             scores, angles = (
                 np.zeros(self.search_size, dtype=np.float32) + float("-inf"),
-                np.zeros(self.search_size, dtype=np.float32) + float("inf"),
+                np.zeros(self.search_size, dtype=np.float32) + float("-inf"),
             )
             for job, s, a in zip(self.sub_jobs, score_volumes, angle_volumes):
                 sub_scores = s[

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -29,9 +29,8 @@ class TestExtract(unittest.TestCase):
         volume[:42, 42:, 24:42] = 0
         ref = predict_tophat_mask(volume)
         volume[:42, 42:, 24:42] = float("-inf")
-        self.assertEqual(
-            ref,
-            predict_tophat_mask(volume),
+        self.assertTrue(
+            np.all(ref == predict_tophat_mask(volume)),
             msg="0 or -inf should behave (almost) identical",
         )
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -25,6 +25,16 @@ class TestExtract(unittest.TestCase):
             tophat_mask.sum(), 0, msg="float16 scores failing for tophat mask"
         )
 
+        # test that -inf is dealt with as well
+        volume[:42, 42:, 24:42] = 0
+        ref = predict_tophat_mask(volume)
+        volume[:42, 42:, 24:42] = float("-inf")
+        self.assertEqual(
+            ref,
+            predict_tophat_mask(volume),
+            msg="0 or -inf should behave (almost) identical",
+        )
+
     # part of the extraction test in test_tmjob.py
     # def test_extract_job_with_tomogram_mask(self):
     #    pass

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -1025,6 +1025,8 @@ class TestTMJob(unittest.TestCase):
                     100,
                     5,
                 )
+
+        job = self.job.copy()
         for i in [float("inf"), float("nan")]:
             job.job_stats["std"] = i
             with self.assertRaisesRegex(ValueError, "std.*NaN or inf"):

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -1015,6 +1015,25 @@ class TestTMJob(unittest.TestCase):
         )
         # We don't look for the plots, they might be skipped if no plotting is available
 
+        # Test raise on faulty stats
+        job = self.job.copy()
+        for i in [float("inf"), float("nan")]:
+            job.job_stats["variance"] = i
+            with self.assertRaisesRegex(ValueError, "variance.*NaN or inf"):
+                _, _ = extract_particles(
+                    job,
+                    100,
+                    5,
+                )
+        for i in [float("inf"), float("nan")]:
+            job.job_stats["std"] = i
+            with self.assertRaisesRegex(ValueError, "std.*NaN or inf"):
+                _, _ = extract_particles(
+                    job,
+                    100,
+                    5,
+                )
+
     def test_get_defocus_offsets(self):
         ts_metadata = TiltSeriesMetaData(tilt_angles=list(range(-51, 54, 3)))
         x_offset_um = 200 * 13.79 * 1e-4


### PR DESCRIPTION
as -1000 is a valid index in a lot of angle lists, this might lead to weird results.
~Try setting to NaN instead~

- [ ] ~change init value to NaN from -1000~
- [ ] ~make sure the NaNs are not propagated in statistics~

[Edit]: NaNs were propagating all over the place, decided to swap with `-inf` instead
- [x] change init value from -1000 to -inf both in the main TMJob and when merging subjobs
- [x] make sure the regular and tophat extraction can deal with -inf in the data
- [x] specifically for the tophat transform, we set the value to 0 (background) and then ignore them in the histogram 

closes #338 