### PR TITLE
Deal with dropped args

### DIFF
--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1033,7 +1033,7 @@ def match_template(argv=None):
             )
             for defocus in args.defocus
         ]
-
+    dropped_args = []
     if args.relion5_tomograms_star is not None:
         voxel_size, ts_metadata = parse_relion5_star_data(
             args.relion5_tomograms_star,
@@ -1041,6 +1041,18 @@ def match_template(argv=None):
             phase_flip_correction=phase_flip_correction,
             phase_shift=args.phase_shift,
         )
+        dropped_args += [
+            "--defocus",
+            "--amplitude_contrast",
+            "--voltage",
+            "--spherical-aberration",
+            ("-a", "--tilt-angles"),
+            "--per-tilt-weighting",
+            "--warp-xml-file",
+            "--voxel-size-angstrom",
+            "--dose-accumulation",
+            "--defocus-handedness",
+        ]
 
     elif args.warp_xml_file is not None:
         voxel_size, ts_metadata = parse_warp_xml_data(
@@ -1050,6 +1062,16 @@ def match_template(argv=None):
         )
         # Replace is needed here to rerun the sanity checking
         ts_metadata = ts_metadata.replace(defocus_handedness=args.defocus_handedness)
+        dropped_args += [
+            "--defocus",
+            "--amplitude_contrast",
+            "--voltage",
+            "--spherical-aberration",
+            ("-a", "--tilt-angles"),
+            "--per-tilt-weighting",
+            "--voxel-size-angstrom",
+            "--dose-accumulation",
+        ]
 
     else:
         if tilt_angles is None:
@@ -1066,6 +1088,24 @@ def match_template(argv=None):
             defocus_handedness=args.defocus_handedness,
             per_tilt_weighting=args.per_tilt_weighting,
         )
+
+    # Warn for dropped args, use new parser to deal with possible shorthand
+    test_input = argparse.ArgumentParser(
+        add_help=False, argument_default=argparse.SUPPRESS
+    )
+    for arg in dropped_args:
+        if isinstance(arg, tuple):
+            short, long = arg
+            test_input.add_argument(
+                short, long, nargs="*", action="store_const", const=f"-{short}/--{long}"
+            )
+        else:
+            test_input.add_argument(
+                arg, nargs="*", action="store_const", const=f"--{arg}"
+            )
+    test_args, _ = test_input.parse_known_args(args)
+    for val in vars(test_args.values()):
+        logging.warn(f"The following input argument was ignored: {val}")
 
     if args.angular_search is None and args.particle_diameter is None:
         raise ValueError(

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1096,21 +1096,21 @@ def match_template(argv=None):
         )
 
     # Warn for dropped args, use new parser to deal with possible shorthand
-    test_input = argparse.ArgumentParser(
+    check_input = argparse.ArgumentParser(
         add_help=False, argument_default=argparse.SUPPRESS
     )
     for arg in dropped_args:
         if isinstance(arg, tuple):
             short, long = arg
-            test_input.add_argument(
+            check_input.add_argument(
                 short, long, action="store_const", const=f"{short}/{long}"
             )
         else:
-            test_input.add_argument(arg, action="store_const", const=f"{arg}")
+            check_input.add_argument(arg, action="store_const", const=f"{arg}")
     # drop any input values that were not options
-    test_argv = [i for i in argv if "-" in i]
-    test_args, _ = test_input.parse_known_args(test_argv)
-    for val in vars(test_args).values():
+    check_argv = [i for i in argv if "-" in i]
+    check_args, _ = check_input.parse_known_args(check_argv)
+    for val in vars(check_args).values():
         logging.warning(f"The following input argument was ignored: {val}")
 
     if args.angular_search is None and args.particle_diameter is None:

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1097,13 +1097,13 @@ def match_template(argv=None):
         if isinstance(arg, tuple):
             short, long = arg
             test_input.add_argument(
-                short, long, nargs="*", action="store_const", const=f"-{short}/--{long}"
+                short, long, action="store_const", const=f"-{short}/--{long}"
             )
         else:
-            test_input.add_argument(
-                arg, nargs="*", action="store_const", const=f"--{arg}"
-            )
-    test_args, _ = test_input.parse_known_args(argv)
+            test_input.add_argument(arg, action="store_const", const=f"--{arg}")
+    # drop any input values that were not options
+    test_argv = [i for i in argv if "-" in argv]
+    test_args, _ = test_input.parse_known_args(test_argv)
     for val in vars(test_args).values():
         logging.warn(f"The following input argument was ignored: {val}")
 

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1104,7 +1104,7 @@ def match_template(argv=None):
                 arg, nargs="*", action="store_const", const=f"--{arg}"
             )
     test_args, _ = test_input.parse_known_args(argv)
-    for val in vars(test_args.values()):
+    for val in vars(test_args).values():
         logging.warn(f"The following input argument was ignored: {val}")
 
     if args.angular_search is None and args.particle_diameter is None:

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1103,7 +1103,7 @@ def match_template(argv=None):
             test_input.add_argument(
                 arg, nargs="*", action="store_const", const=f"--{arg}"
             )
-    test_args, _ = test_input.parse_known_args(args)
+    test_args, _ = test_input.parse_known_args(argv)
     for val in vars(test_args.values()):
         logging.warn(f"The following input argument was ignored: {val}")
 

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1110,7 +1110,7 @@ def match_template(argv=None):
     test_argv = [i for i in argv if "-" in i]
     test_args, _ = test_input.parse_known_args(test_argv)
     for val in vars(test_args).values():
-        logging.warn(f"The following input argument was ignored: {val}")
+        logging.warning(f"The following input argument was ignored: {val}")
 
     if args.angular_search is None and args.particle_diameter is None:
         raise ValueError(

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1076,6 +1076,7 @@ def match_template(argv=None):
             "--per-tilt-weighting",
             "--voxel-size-angstrom",
             "--dose-accumulation",
+            "--phase-shift",
         ]
 
     else:

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -987,8 +987,13 @@ def match_template(argv=None):
 
     # ---8<--- [end:match_template_usage]
 
+    # Add hidden argument to prevent logging override for logtests
+    parser.add_argument(
+        "--log-test", help=argparse.SUPPRESS, action="store_true", default=False
+    )
     args = parser.parse_args(argv)
-    logging.basicConfig(level=args.log, force=True)
+    if not args.log_test:
+        logging.basicConfig(level=args.log, force=True)
 
     # set rng if not set
     if args.rng_seed is None:

--- a/src/pytom_tm/entry_points.py
+++ b/src/pytom_tm/entry_points.py
@@ -1048,7 +1048,7 @@ def match_template(argv=None):
         )
         dropped_args += [
             "--defocus",
-            "--amplitude_contrast",
+            "--amplitude-contrast",
             "--voltage",
             "--spherical-aberration",
             ("-a", "--tilt-angles"),
@@ -1069,7 +1069,7 @@ def match_template(argv=None):
         ts_metadata = ts_metadata.replace(defocus_handedness=args.defocus_handedness)
         dropped_args += [
             "--defocus",
-            "--amplitude_contrast",
+            "--amplitude-contrast",
             "--voltage",
             "--spherical-aberration",
             ("-a", "--tilt-angles"),
@@ -1102,12 +1102,12 @@ def match_template(argv=None):
         if isinstance(arg, tuple):
             short, long = arg
             test_input.add_argument(
-                short, long, action="store_const", const=f"-{short}/--{long}"
+                short, long, action="store_const", const=f"{short}/{long}"
             )
         else:
-            test_input.add_argument(arg, action="store_const", const=f"--{arg}")
+            test_input.add_argument(arg, action="store_const", const=f"{arg}")
     # drop any input values that were not options
-    test_argv = [i for i in argv if "-" in argv]
+    test_argv = [i for i in argv if "-" in i]
     test_args, _ = test_input.parse_known_args(test_argv)
     for val in vars(test_args).values():
         logging.warn(f"The following input argument was ignored: {val}")

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -574,7 +574,7 @@ class TestEntryPoints(unittest.TestCase):
         # and phase shift for warp but not for relion
         arguments = match_defaults.copy()
         arguments["--defocus-handedness"] = "0"
-        arguments["--phase-shift"] = "0"
+        arguments["--phase-shift"] = "1"
         with self.assertLogs(level="WARNING") as cm:
             entry_points.match_template(prep_argv(arguments))
         logs = " ".join(cm.output)
@@ -585,7 +585,7 @@ class TestEntryPoints(unittest.TestCase):
         # but a log for phase shift
         arguments = match_defaults.copy()
         arguments["--defocus-handedness"] = "0"
-        arguments["--phase-shift"] = "0"
+        arguments["--phase-shift"] = "1"
         del arguments["--relion5-tomograms-star"]
         arguments["--warp-xml-file"] = str(WARP_XML)
         with self.assertLogs(level="WARNING") as cm:

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -514,14 +514,14 @@ class TestEntryPoints(unittest.TestCase):
             "--amplitude-contrast",
             "--voltage",
             "--spherical-aberration",
-            "--voltage",
             "--tilt-angles",
             "--per-tilt-weighting",
             "--dose-accumulation",
         ]
         # test 1 line per dropped option
         self.assertEqual(
-            len([i for i in cm.output if "WARN" in i]), len(dropped_options)
+            len([i for i in cm.output if ("WARN" in i and "-" in i)]),
+            len(dropped_options),
         )
         logs = " ".join(cm.output)
         for i in dropped_options:
@@ -548,7 +548,7 @@ class TestEntryPoints(unittest.TestCase):
         # make sure we log on both relion and warp xml
         # TODO: is this actually intended behavior or should we error on this?
         arguments = match_defaults.copy()
-        arguments["--warp-xml"] = "fake.xml"
+        arguments["--warp-xml"] = str(WARP_XML)
         with self.assertLogs(level="WARNING") as cm:
             entry_points.match_template(prep_argv(arguments))
         logs = " ".join(cm.output)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -482,3 +482,92 @@ class TestEntryPoints(unittest.TestCase):
         # make sure we can run extraction
         start(extract_defaults)
         self.assertTrue((self.outputdir / f"{tomo_id}_particles.star").exists())
+
+    @unittest.mock.patch("pytom_tm.parallel.run_job_parallel")
+    def test_dropped_logging(self, mock_run):
+        # mock out the actuall running to speed up this test
+        mock_run.return_value = (np.random.rand(5), np.random.rand(5))
+        match_defaults = {
+            "-t": str(TEMPLATE),
+            "-m": str(MASK),
+            "-v": str(TOMOGRAM),
+            "-d": str(self.outputdir),
+            "--angular-search": "35",
+            "--tilt-angles": str(TILT_ANGLES),
+            "--per-tilt-weighting": "",
+            "--dose-accumulation": str(DOSE),
+            "--defocus": str(DEFOCUS_IMOD),
+            "--amplitude-contrast": "0.08",
+            "--spherical-aberration": "2.7",
+            "--voltage": "300",
+            "--tomogram-ctf-model": "phase-flip",
+            "-g": "0",
+            "--relion5-tomograms-star": str(RELION5_TOMOGRAMS_STAR),
+            "--log-test": "",
+        }
+        # make sure we at least log
+        arguments = match_defaults.copy()
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        dropped_options = [
+            "--defocus",
+            "--amplitude-contrast",
+            "--voltage",
+            "--spherical-aberration",
+            "--voltage",
+            "--tilt-angles",
+            "--per-tilt-weighting",
+            "--dose-accumulation",
+        ]
+        # test 1 line per dropped option
+        self.assertEqual(
+            len([i for i in cm.output if "WARN" in i]), len(dropped_options)
+        )
+        logs = " ".join(cm.output)
+        for i in dropped_options:
+            self.assertIn(i, logs)
+
+        # make sure we also log on shorthand
+        arguments = match_defaults.copy()
+        del arguments["--tilt-angles"]
+        arguments["-a"] = str(TILT_ANGLES)
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        logs = " ".join(cm.output)
+        self.assertIn("--tilt-angles", logs)
+
+        # make sure we also log on abbreviations
+        arguments = match_defaults.copy()
+        del arguments["--per-tilt-weighting"]
+        arguments["--per-tilt"] = ""
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        logs = " ".join(cm.output)
+        self.assertIn("--per-tilt-weighting", logs)
+
+        # make sure we log on both relion and warp xml
+        # TODO: is this actually intended behavior or should we error on this?
+        arguments = match_defaults.copy()
+        arguments["--warp-xml"] = "fake.xml"
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        logs = " ".join(cm.output)
+        self.assertIn("--warp-xml-file", logs)
+
+        # make sure we log defocus handedness for relion but not for warp
+        arguments = match_defaults.copy()
+        arguments["--defocus-handedness"] = "0"
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        logs = " ".join(cm.output)
+        self.assertIn("--defocus-handedness", logs)
+
+        # make sure no log for defocus handedness in warp
+        arguments = match_defaults.copy()
+        arguments["--defocus-handedness"] = "0"
+        del arguments["--relion5-tomograms-star"]
+        arguments["--warp-xml-file"] = str(WARP_XML)
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
+        logs = " ".join(cm.output)
+        self.assertNotIn("--defocus-handedness", logs)

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -486,7 +486,7 @@ class TestEntryPoints(unittest.TestCase):
     @unittest.mock.patch("pytom_tm.parallel.run_job_parallel")
     def test_dropped_logging(self, mock_run):
         # mock out the actuall running to speed up this test
-        mock_run.return_value = (np.random.rand((5, 5, 5)), np.random.rand((5, 5, 5)))
+        mock_run.return_value = (np.random.rand(5, 5, 5), np.random.rand(5, 5, 5))
         match_defaults = {
             "-t": str(TEMPLATE),
             "-m": str(MASK),

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -492,7 +492,7 @@ class TestEntryPoints(unittest.TestCase):
             "-m": str(MASK),
             "-v": str(RELION5_TOMOGRAM),
             "-d": str(self.outputdir),
-            "--voxel-size-angstrom": 1,
+            "--voxel-size-angstrom": "1",
             "--angular-search": "35",
             "--tilt-angles": str(TILT_ANGLES),
             "--per-tilt-weighting": "",

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -486,7 +486,7 @@ class TestEntryPoints(unittest.TestCase):
     @unittest.mock.patch("pytom_tm.parallel.run_job_parallel")
     def test_dropped_logging(self, mock_run):
         # mock out the actuall running to speed up this test
-        mock_run.return_value = (np.random.rand(5), np.random.rand(5))
+        mock_run.return_value = (np.random.rand((5, 5, 5)), np.random.rand((5, 5, 5)))
         match_defaults = {
             "-t": str(TEMPLATE),
             "-m": str(MASK),

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -492,6 +492,7 @@ class TestEntryPoints(unittest.TestCase):
             "-m": str(MASK),
             "-v": str(RELION5_TOMOGRAM),
             "-d": str(self.outputdir),
+            "--voxel-size-angstrom": 1,
             "--angular-search": "35",
             "--tilt-angles": str(TILT_ANGLES),
             "--per-tilt-weighting": "",
@@ -517,8 +518,23 @@ class TestEntryPoints(unittest.TestCase):
             "--tilt-angles",
             "--per-tilt-weighting",
             "--dose-accumulation",
+            "--voxel-size-angstrom",
         ]
         # test 1 line per dropped option
+        self.assertEqual(
+            len([i for i in cm.output if ("WARN" in i and "-" in i)]),
+            len(dropped_options),
+        )
+        logs = " ".join(cm.output)
+        for i in dropped_options:
+            self.assertIn(i, logs)
+
+        # repeat for warp-xml
+        arguments = match_defaults.copy()
+        del arguments["--relion5-tomograms-star"]
+        arguments["--warp-xml-file"] = str(WARP_XML)
+        with self.assertLogs(level="WARNING") as cm:
+            entry_points.match_template(prep_argv(arguments))
         self.assertEqual(
             len([i for i in cm.output if ("WARN" in i and "-" in i)]),
             len(dropped_options),

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -490,7 +490,7 @@ class TestEntryPoints(unittest.TestCase):
         match_defaults = {
             "-t": str(TEMPLATE),
             "-m": str(MASK),
-            "-v": str(TOMOGRAM),
+            "-v": str(RELION5_TOMOGRAM),
             "-d": str(self.outputdir),
             "--angular-search": "35",
             "--tilt-angles": str(TILT_ANGLES),

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -571,19 +571,25 @@ class TestEntryPoints(unittest.TestCase):
         self.assertIn("--warp-xml-file", logs)
 
         # make sure we log defocus handedness for relion but not for warp
+        # and phase shift for warp but not for relion
         arguments = match_defaults.copy()
         arguments["--defocus-handedness"] = "0"
+        arguments["--phase-shift"] = "0"
         with self.assertLogs(level="WARNING") as cm:
             entry_points.match_template(prep_argv(arguments))
         logs = " ".join(cm.output)
         self.assertIn("--defocus-handedness", logs)
+        self.assertNotIn("--phase-shift", logs)
 
         # make sure no log for defocus handedness in warp
+        # but a log for phase shift
         arguments = match_defaults.copy()
         arguments["--defocus-handedness"] = "0"
+        arguments["--phase-shift"] = "0"
         del arguments["--relion5-tomograms-star"]
         arguments["--warp-xml-file"] = str(WARP_XML)
         with self.assertLogs(level="WARNING") as cm:
             entry_points.match_template(prep_argv(arguments))
         logs = " ".join(cm.output)
         self.assertNotIn("--defocus-handedness", logs)
+        self.assertIn("--phase-shift", logs)


### PR DESCRIPTION
closes #335 
for now I decided to output a warning
- [x] implement code
- [x] implement test
- [x] test long/short/abbreviated options

When reviewing, please give me your opinion on the following alternatives:
- Error when there are dropped args at all
- Error normally, but let users provide a flag if they want to use it to override warp/relion data instead
- Warn normally, but let users provide a flag if they want to use it to override warp/relion data

For the last 2 options do you want to first merge this PR or already implement the new flag in this PR as well (would require a big rewrite as the whole ctf data block that happens before the relion/warp parsing then needs to account for missing args) https://github.com/SBC-Utrecht/pytom-match-pick/blob/9fd5388fb56d8122cd26c507114e88741e018f3e/src/pytom_tm/entry_points.py#L1014-L1035