### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       # Allow to check commit statusses
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -14,7 +14,7 @@ jobs:
       options: --runtime=nvidia --gpus all
     steps:
       - name: Pull code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install build and twine
         run: |
           python -m pip install --upgrade build twine
@@ -39,7 +39,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: match-pick-distributions
         path: dist/
@@ -63,7 +63,7 @@ jobs:
         run: |
           python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pytom-match-pick[plotting]
       - name: Pull test code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run tests on the installed package
         run: |
           python -m unittest discover tests/
@@ -77,7 +77,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: match-pick-distributions
         path: dist/

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m twine check dist/*
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: match-pick-distributions
           path: dist/

--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: ./docs/tutorials
     steps:
       - name: Pull code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies, code, and list everything
         working-directory: ./
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       options: --runtime=nvidia --gpus all
     steps:
       - name: Pull code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           conda install -y -c conda-forge python=3 cupy cuda-version=11.8 gcc #gcc only needed until healpix releases under numpy>2
@@ -51,7 +51,7 @@ jobs:
           coverage xml
           echo ${{ github.event.number }} > coverage.PR
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: 
           path: coverage.*
           name: coverage
@@ -62,7 +62,7 @@ jobs:
       options: --runtime=nvidia --gpus all
     steps:
       - name: Pull code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           conda install -y -c conda-forge python=3.11 cupy cuda-version=11.8 gcc #gcc only needed until healpix releases under numpy>2


### PR DESCRIPTION
The following warning started popping up in our tests:
```
Warning: Node.js 20 actions are deprecated. 
The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4. 
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. 
Please check if updated versions of these actions are available that support Node.js 24. 
To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. 
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

started by updating our standard actions to the newest available version