### PR TITLE
make doc building work with zensical

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install mkdocs mkdocs-material markdown-exec mkdocs-glightbox
+          pip install zensical mkdocs-material markdown-exec[ansi] mkdocs-glightbox
 
       # Build the book
       - name: Build the book
         run: |
-          mkdocs build
+          zensical build
 
       # Push the site to github-pages
       - name: GitHub Pages action

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This software is developed by Marten L. Chaillet ([@McHaillet](https://github.co
 ![cover_image](docs/images/tomo200528_100_illustration.png)
 
 <!--
-This line starts the block that is incorporated into the website via mkdocs snippets
+This line starts the block that is incorporated into the website via zensical snippets
 -->
 [//]: # (#--8<-- [start:docs])
 
@@ -123,7 +123,7 @@ This uses Ruff to check and format whenever you make commits.
 If you update anything in the (documentation) `docs/` folder make sure to test build the website locally:
 
 ```commandline
-mkdocs serve
+zensical serve
 ```
 
 ## Tests

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,12 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: ["README.md", "src/pytom_tm/entry_points.py"]
       check_paths: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: python
+          class: python
+          format: !!python/name:markdown_exec.formatter
+          validator: !!python/name:markdown_exec.validator
   - pymdownx.arithmatex:
       generic: true
   - attr_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 plotting = ["matplotlib", "seaborn"]
-dev = ["ruff", "pre-commit", "mkdocs", "mkdocs-material", "markdown-exec", "mkdocs-glightbox"]
+dev = ["ruff", "pre-commit", "zensical", "mkdocs-material", "markdown-exec", "mkdocs-glightbox"]
 all = ["pytom-match-pick[plotting]", "pytom-match-pick[dev]"]
 
 


### PR DESCRIPTION
closes #344 

Swaps the workflow to use `zensical` instead of mkdocs

The changes to the `yml` make the arguments code blocks render properly with `zensical` (as `markdown_exec` is not (yet) supported directly as a plugin by `zensical`) (it is also the same as the markdown-extension configuration on the [`markdown-exec readme`](https://github.com/pawamoy/markdown-exec?tab=readme-ov-file#configuration), instead of the `plugin` example we currently have)

I decided to swap to zensical as they are the authors of Material for MkDocs which we already use for the theming of our docs. As opposed to the other alternative [properdocs](properdocs.org) which was started by someone who seems to have tried several less-than-friendly takeovers of mkdocs, which I find partly understandable, but kinda unforgivable.

I am open to discuss other possible replacement doc builders

[EDIT]: I have just realized zensical does not seem to support glightbox for the image zoom. Won't hang the PR on that, but is relevant to know. It is on [their backlog](https://github.com/zensical/backlog/issues/21) and classified as [TIER 1](https://zensical.org/compatibility/plugins/)