### PR TITLE
Move some imports to make GPU optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-match-pick"
-version = "0.14.0"
+version = "0.14.1"
 description = "PyTOM's GPU template matching module as an independent package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -895,6 +895,7 @@ class TMJob:
             with search statistics
         """
         from pytom_tm.matching import TemplateMatchingGPU
+
         tomo = read_mrc(self.tomogram)
         fast_tomo = np.zeros(
             tuple([next_fast_len(s, real=True) for s in tomo.shape]),

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -10,7 +10,6 @@ import json
 import logging
 from scipy.fft import next_fast_len, rfftn, irfftn
 from pytom_tm.angles import get_angle_list
-from pytom_tm.matching import TemplateMatchingGPU
 from pytom_tm.weights import (
     create_wedge,
     power_spectrum_profile,
@@ -895,6 +894,7 @@ class TMJob:
             angle map), when no volumes are returned the output consists of a dictionary
             with search statistics
         """
+        from pytom_tm.matching import TemplateMatchingGPU
         tomo = read_mrc(self.tomogram)
         fast_tomo = np.zeros(
             tuple([next_fast_len(s, real=True) for s in tomo.shape]),

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -17,7 +17,6 @@ from pytom_tm.angles import get_angle_list
 from pytom_tm.dataclass import CtfData, RelionTiltSeriesMetaData, TiltSeriesMetaData
 from pytom_tm.io import UnequalSpacingError, read_mrc, read_mrc_meta_data, write_mrc
 from pytom_tm.json import CustomJSONDecoder, CustomJSONEncoder
-
 from pytom_tm.weights import (
     create_gaussian_band_pass,
     create_wedge,

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -1,7 +1,6 @@
 import numpy as np
 import numpy.typing as npt
 import scipy.ndimage as ndimage
-import voltools as vt
 from pytom_tm.io import UnequalSpacingError
 from pytom_tm.dataclass import CtfData, TiltSeriesMetaData
 from itertools import pairwise
@@ -542,6 +541,7 @@ def _create_tilt_weighted_wedge(
             "dimensions."
         )
 
+    import voltools as vt
     image_size = shape[0]  # assign to size variable as all dimensions are equal size
     tilt = np.zeros(shape)
     q_grid = radial_reduced_grid(shape)

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -542,6 +542,7 @@ def _create_tilt_weighted_wedge(
         )
 
     import voltools as vt
+
     image_size = shape[0]  # assign to size variable as all dimensions are equal size
     tilt = np.zeros(shape)
     q_grid = radial_reduced_grid(shape)

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.typing as npt
 import scipy.ndimage as ndimage
+from typing import Generator
 from pytom_tm.io import UnequalSpacingError
 from pytom_tm.dataclass import CtfData, TiltSeriesMetaData
 from itertools import pairwise

--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -3,7 +3,6 @@ from itertools import pairwise
 
 import numpy as np
 import numpy.typing as npt
-
 from scipy import ndimage
 
 from pytom_tm.dataclass import CtfData, TiltSeriesMetaData

--- a/tests/test_no_gpu.py
+++ b/tests/test_no_gpu.py
@@ -1,0 +1,56 @@
+# tests/test_no_gpu.py
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+def _run_without_gpu_libs(code: str) -> subprocess.CompletedProcess:
+    """Run `code` in a fresh subprocess where importing cupy/voltools
+    (and their submodules) always raises ImportError, simulating a
+    machine with no working GPU/CUDA install -- regardless of whether
+    the host actually has one. This function does not check the return code
+    and expects any tests using it to check the return code explicitly.
+    This file was introduced to test PR #346"""
+    setup = textwrap.dedent(
+        """
+        import builtins
+        _real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "cupy" or name.startswith("cupy.") \\
+               or name == "voltools" or name.startswith("voltools."):
+                raise ImportError(f"simulated missing GPU: no module '{name}'")
+            return _real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _fake_import
+        """
+    )
+    full_script = setup + "\n" + textwrap.dedent(code)
+    return subprocess.run(
+        [sys.executable, "-c", full_script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+class TestEntryPointsWithoutGPU(unittest.TestCase):
+    def test_merge_stars_importable_without_gpu(self):
+        result = _run_without_gpu_libs(
+            """
+            from pytom_tm.entry_points import merge_stars
+            merge_stars(['--help'])
+            """
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_extract_candidates_importable_without_gpu(self):
+        result = _run_without_gpu_libs(
+            """
+            from pytom_tm.entry_points import extract_candidates
+            extract_candidates(['--help'])
+            """
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
Hello,
I'm using pytom-match-pick on a HPC cluster and love it. Though one issue I'm having is that I sometimes play with the false positive rate or cutoff and I don't want to submit that as GPU-bound jobs. The same applies to merging star files.

I figured I could just move around some imports to make it not fail when there's no GPU. It still requires Cuda for installation though.