### PR TITLE
Fix divide-by-zero in tilt_increment for duplicate tilt angles

### DIFF
--- a/src/pytom_tm/weights.py
+++ b/src/pytom_tm/weights.py
@@ -548,7 +548,7 @@ def _create_tilt_weighted_wedge(
     tilt_weighted_wedge = np.zeros((image_size, image_size, image_size // 2 + 1))
 
     # create ramp weights to correct tilt summation for overlap
-    tilt_increment = min([abs(x - y) for x, y in pairwise(tilt_angles)])
+    tilt_increment = min([abs(x - y) for x, y in pairwise(sorted(set(tilt_angles)))])
     # Crowther freq. determines till what point adjacent tilts overlap in Fourier space
     overlap_frequency = 1 / (tilt_increment * image_size)
     freq_1d = (


### PR DESCRIPTION
Fixes #348.

Bidirectional tilt schemes acquire two images at 0° (one per half). When the tilt angle list is sorted, adjacent `0.0` entries produce a pairwise difference of 0, making `tilt_increment = 0` and `overlap_frequency = inf`. This zeros out the ramp filter, the wedge, and all correlation scores.

**Fix:** Use `sorted(set(tilt_angles))` to compute `tilt_increment` from unique angles only. One line changed. The per-tilt weighting loop is unchanged and still uses all tilts including duplicates for dose/CTF weighting.