### PR TITLE
Fix inflated sigma when using random-phase noise correction

### DIFF
--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -231,6 +231,13 @@ def extract_particles(
                 f"job stat '{x}' is NaN or inf, please check your volumes and update "
                 "the job_stats json accordingly"
             )
+    if job.random_phase_correction and "sigma_noise" in job.job_stats:
+        for x in ["sigma_real", "sigma_noise"]:
+            if math.isinf(job.job_stats[x]) or math.isnan(job.job_stats[x]):
+                raise ValueError(
+                    f"job stat '{x}' is NaN or inf, please check your volumes "
+                    "and update the job_stats json accordingly"
+                )
 
     sigma = job.job_stats["std"]
     search_space = job.job_stats["search_space"]
@@ -306,11 +313,29 @@ def extract_particles(
     score_volume[:, :, -particle_radius_px:] = 0
 
     if cut_off is None:
-        # formula Rickgauer et al. (2017, eLife):
-        # N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
-        # we need to find theta (i.e. the cut off)
-        cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * sigma
-        logging.info(f"cut off for particle extraction: {cut_off}")
+        if job.random_phase_correction and "sigma_noise" in job.job_stats:
+            # Noise-corrected scores follow a logistic distribution (difference
+            # of two Gumbels), not Gaussian. Use the logistic tail formula.
+            sigma_real = job.job_stats["sigma_real"]
+            sigma_noise = job.job_stats["sigma_noise"]
+            n_angles = job.n_rotations
+            n_voxels = score_volume.size  # corrected search space is per-voxel
+            beta_eff = np.sqrt(
+                (sigma_real**2 + sigma_noise**2) / (4 * np.log(n_angles))
+            )
+            cut_off = beta_eff * np.log(n_voxels / n_false_positives)
+            logging.info(
+                f"Noise-corrected logistic cut-off: {cut_off:.6f} "
+                f"(sigma_real={sigma_real:.6f}, sigma_noise={sigma_noise:.6f}, "
+                f"beta_eff={beta_eff:.6f}, n_voxels={n_voxels}, n_angles={n_angles})"
+            )
+        else:
+            # Standard Rickgauer formula (Gaussian tail)
+            # N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
+            cut_off = (
+                erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * sigma
+            )
+            logging.info(f"cut off for particle extraction: {cut_off}")
     elif cut_off < 0:
         logging.warning(
             "Provided extraction score cut-off is smaller than 0. Changing to 0 as "

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -183,6 +183,8 @@ class TemplateMatchingGPU:
         self.angle_list = angle_list
         self.angle_ids = angle_ids
         self.stats = {"search_space": 0, "variance": 0.0, "std": 0.0}
+        if noise_correction:
+            self.stats["noise_variance"] = 0.0
         if stats_roi is None:
             self.stats_roi = (slice(None), slice(None), slice(None))
         else:
@@ -322,6 +324,10 @@ class TemplateMatchingGPU:
                     self.plan.noise_scores,
                 )
 
+                self.stats["noise_variance"] += (
+                    square_sum_kernel(self.plan.ccc_map * roi_mask) / roi_size
+                )
+
         # do the noise correction on the scores map: substract the noise scores first,
         # and then add the noise mean to ensure stats are consistent
         if self.noise_correction:
@@ -341,6 +347,14 @@ class TemplateMatchingGPU:
         self.stats["search_space"] = int(roi_size * len(self.angle_ids))
         self.stats["variance"] = float(self.stats["variance"] / len(self.angle_ids))
         self.stats["std"] = float(cp.sqrt(self.stats["variance"]))
+        if self.noise_correction:
+            self.stats["noise_variance"] = float(
+                self.stats["noise_variance"] / len(self.angle_ids)
+            )
+            self.stats["sigma_real"] = self.stats["std"]
+            self.stats["sigma_noise"] = float(
+                cp.sqrt(self.stats["noise_variance"])
+            )
 
         # package results back to the CPU
         results = (self.plan.scores.get(), self.plan.angles.get(), self.stats)

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -823,6 +823,14 @@ class TMJob:
                 "variance": variance,
                 "std": np.sqrt(variance),
             }
+            # Merge noise correction stats if present
+            if "noise_variance" in stats[0]:
+                noise_variance = sum(
+                    [s["noise_variance"] for s in stats]
+                ) / len(stats)
+                self.job_stats["noise_variance"] = noise_variance
+                self.job_stats["sigma_real"] = np.sqrt(variance)
+                self.job_stats["sigma_noise"] = np.sqrt(noise_variance)
 
         is_subvolume_split = np.all(
             np.array([x.start_slice for x in self.sub_jobs]) == 0


### PR DESCRIPTION
Fixes #350.

When `--random-phase-correction` is enabled, `stats["std"]` is computed from pre-correction CCC maps but used for cutoff estimation on post-correction scores. The noise correction reduces effective noise, so the pre-correction sigma is inflated, producing a cutoff that misses real particles.

Recompute variance/std from the corrected score map within the ROI after noise correction. The non-corrected path is unchanged.