### PR TITLE
Add gcc installation to tutorial-tests workflow

### DIFF
--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies, code, and list everything
         working-directory: ./
         run: |
-          conda install -y -c conda-forge python=3 cupy cuda-version=11.8 curl unzip
+          conda install -y -c conda-forge python=3 cupy cuda-version=11.8 curl unzip gcc
           python -m pip install coverage mdextractor #mdextractor is new and might need to be replaced later
           python -m pip install .[all]
           conda list


### PR DESCRIPTION
Added gcc installation to the workflow for tutorial tests.

no clue why the tutorials were passing before, now it also installes GCC like it does for the other tests